### PR TITLE
Fixes issue in flatfile builder, plus new IMs

### DIFF
--- a/smtk/sm_utils.py
+++ b/smtk/sm_utils.py
@@ -15,6 +15,11 @@ def get_time_vector(time_step, number_steps):
     return np.cumsum(time_step * np.ones(number_steps, dtype=float)) -\
         time_step
 
+def nextpow2(nval):
+    m_f = np.log2(nval)
+    m_i = np.ceil(m_f)
+    return int(2.0 ** m_i)
+
 def convert_accel_units(acceleration, units):
     """
     Converts acceleration to different units


### PR DESCRIPTION
This PR fixes a bug in the add_horizontal_ims feature  of the sm_database_builder that prevented calculation of the horizontal response spectra when the X and Y input spectra were not available.

Some new features:
1) Implements RotDpp intensity measure of Boore (2010)
2) Implements RotIpp intensity measure of Boore (2010)
3) Add a "get_fourier_spectrum" method to the intensity measures to return the Fourier spectrum of a record.
