### PR TITLE
 Unit issue in simple parser

### DIFF
--- a/smtk/parsers/simple_flatfile_parser.py
+++ b/smtk/parsers/simple_flatfile_parser.py
@@ -306,6 +306,7 @@ class SimpleAsciiTimeseriesReader(SMTimeSeriesReader):
         nvals, time_step = (getline(ifile, 1).rstrip("\n")).split()
         output["Time-step"] = float(time_step)
         output["Number Steps"] = int(nvals)
-        output["Units"] = self.units
+        #output["Units"] = self.units
+        output["Units"] = "cm/s/s"
         output["PGA"] = np.max(np.fabs(output["Acceleration"]))
         return output


### PR DESCRIPTION
Mistake in the parser. Data are originally in m/s/s (or whatever unit), they are converted in cm/s/s within the parser (ParseSimpleAscii) but the unit was not updated (attribute unit is still set to the original unit value). This leaded to a double conversion (another conversion is done in the sm_database_builder, method build_time_series_hdf5).
