### PR TITLE
Compatibility flatfile v6 v9 and default site and distance values

### DIFF
--- a/smtk/parsers/simple_flatfile_parser.py
+++ b/smtk/parsers/simple_flatfile_parser.py
@@ -202,7 +202,7 @@ class SimpleFlatfileParser(SMDatabaseReader):
                           metadata["Station ID  No."],
                           get_float(metadata["Station Longitude"]),
                           get_float(metadata["Station Latitude"]),
-                          None, # Elevation data not given
+                          0.0, # Elevation data not given
                           get_float(metadata["Preferred Vs30 (m/s)"]),
                           network_code=metadata["Owner"])
         site.nehrp = metadata["Preferred NEHRP Based on Vs30"]

--- a/smtk/parsers/simple_flatfile_parser.py
+++ b/smtk/parsers/simple_flatfile_parser.py
@@ -17,6 +17,12 @@ from smtk.parsers.base_database_parser import (get_float, get_int,
                                                SMDatabaseReader,
                                                SMTimeSeriesReader,
                                                SMSpectraReader)
+# In order to define default fault dimension import scaling relationships
+from openquake.hazardlib.scalerel.strasser2010 import StrasserInterface, StrasserIntraslab
+from openquake.hazardlib.scalerel.wc1994 import WC1994
+from openquake.hazardlib.geo.mesh import Mesh
+import smtk.trellis.configure as rcfg
+from openquake.hazardlib.geo.point import Point
 
 
 HEADER_LIST = Set(['Record Sequence Number', 'EQID', 'Station Sequence Number',
@@ -93,10 +99,10 @@ class SimpleFlatfileParser(SMDatabaseReader):
         wfid = metadata["Record Sequence Number"]
         # Event information
         event = self._parse_event_data(metadata)
-        # Distance Information
-        distances = self._parse_distance_data(metadata)
         # Site information
         site = self._parse_site_data(metadata)
+        # Distance Information
+        distances = self._parse_distance_data(event, site, metadata)
         # Components
         x_comp, y_comp, vertical = self._parse_processing_data(wfid, metadata)
         # Return record metadata
@@ -152,11 +158,33 @@ class SimpleFlatfileParser(SMDatabaseReader):
             pref_mag,
             focal_mechanism,
             metadata["Country"])
+            
+        hypo_loc = (0.5, 0.7)
+        msr=WC1994()
+        # Warning rake set to 0.0 in scaling relationship
+        area = msr.get_median_area(pref_mag.value,0.0)
+        aspect_ratio = 1.5
+        width_model = np.sqrt(area / aspect_ratio)
+        length_model = aspect_ratio * width_model
+        ztor_model = eqk.depth - width_model/2
+        if ztor_model < 0:
+            ztor_model = 0.0
+
+        length = get_float(metadata["Fault Rupture Length (km)"])
+        if length is None:
+            length = length_model
+        width = get_float(metadata["Fault Rupture Width (km)"])
+        if width is None:
+            width = width_model
+        ztor = get_float(metadata["Depth to Top Of Fault Rupture Model"])
+        if ztor is None:
+            ztor=ztor_model        
+        
         # Rupture
         eqk.rupture = Rupture(eq_id,
-            get_float(metadata["Fault Rupture Length (km)"]),
-            get_float(metadata["Fault Rupture Width (km)"]),
-            get_float(metadata["Depth to Top Of Fault Rupture Model"]))
+            length,
+            width,
+            ztor)
         eqk.rupture.get_area()
         return eqk
             
@@ -166,28 +194,71 @@ class SimpleFlatfileParser(SMDatabaseReader):
         :class: smtk.sigma_database.FocalMechanism 
         """
         nodal_planes = GCMTNodalPlanes()
+        strike = get_float(metadata["Strike (deg)"])
+        if strike is None:
+            strike = 0.0
+        dip = get_float(metadata["Dip (deg)"])
+        if dip is None:
+            dip = 90.0
         nodal_planes.nodal_plane_1 = {
-            "strike": get_float(metadata["Strike (deg)"]),
-            "dip": get_float(metadata["Dip (deg)"]),
+            "strike": strike,
+            "dip": dip,
             "rake": get_float(metadata["Rake Angle (deg)"])}
 
         nodal_planes.nodal_plane2 = {"strike": None,
                                      "dip": None,
                                      "rake": None}
+                                     
         principal_axes = GCMTPrincipalAxes()
         return FocalMechanism(eq_id, eq_name, nodal_planes, principal_axes,
             mechanism_type=metadata["Mechanism Based on Rake Angle"])
 
-    def _parse_distance_data(self, metadata):
+    def _parse_distance_data(self, event, site, metadata):
         """
         Read in the distance related metadata and return an instance of the
         :class: smtk.sm_database.RecordDistance
         """
+        # Compute various distance metrics
+        # Add calculation of Repi, Rhypo from event and station localizations (latitudes, longitudes, depth, elevation)?
+        target_site = Mesh(np.array(site.longitude), np.array(site.latitude), np.array(0.0))
+        # Warning ratio fixed to 1.5
+        ratio=1.5
+        surface_modeled = rcfg.create_planar_surface(Point(event.longitude, event.latitude, event.depth),
+                                             event.mechanism.nodal_planes.nodal_plane_1['strike'],
+                                             event.mechanism.nodal_planes.nodal_plane_1['dip'],
+                                             event.rupture.area,
+                                             ratio)
+        hypocenter = rcfg.get_hypocentre_on_planar_surface(surface_modeled, event.rupture.hypo_loc)
+        
+        # Rhypo
+        Rhypo = get_float(metadata["HypD (km)"])
+        if Rhypo is None:
+            Rhypo = hypocenter.distance_to_mesh(target_site)
+        # Repi
+        Repi = get_float(metadata["EpiD (km)"])
+        if Repi is None:
+            Repi= hypocenter.distance_to_mesh(target_site, with_depths=False)
+        # Rrup
+        Rrup = get_float(metadata["Campbell R Dist. (km)"])
+        if Rrup is None:
+            Rrup = surface_modeled.get_min_distance(target_site)
+        # Rjb
+        Rjb = get_float(metadata["Joyner-Boore Dist. (km)"])
+        if Rjb is None:
+            Rjb = surface_modeled.get_joyner_boore_distance(target_site)
+        # Need to check if Rx and Ry0 are consistant with the other metrics when those are coming from the flatfile?
+        # Rx
+        Rx = surface_modeled.get_rx_distance(target_site)
+        # Ry0
+        Ry0 = surface_modeled.get_ry0_distance(target_site)
+        
         distance = RecordDistance(
-            get_float(metadata["EpiD (km)"]),
-            get_float(metadata["HypD (km)"]),
-            get_float(metadata["Joyner-Boore Dist. (km)"]),
-            get_float(metadata["Campbell R Dist. (km)"]))
+            repi = Repi,
+            rhypo = Rhypo,
+            rjb = Rjb,
+            rrup = Rrup,
+            r_x = Rx,
+            ry0 = Ry0)
         distance.azimuth = get_float(metadata["Source to Site Azimuth (deg)"])
         distance.hanging_wall = get_float(metadata["FW/HW Indicator"])
         return distance
@@ -216,6 +287,13 @@ class SimpleFlatfileParser(SMDatabaseReader):
         site.z1pt0 = get_float(metadata["Z1 (m)"])
         site.z1pt5 = get_float(metadata["Z1.5 (m)"])
         site.z2pt5 = get_float(metadata["Z2.5 (m)"])
+
+        # Implement default values for z1pt0 and z2pt5
+        if site.z1pt0 is None:
+            site.z1pt0 = rcfg.vs30_to_z1pt0_as08(site.vs30)
+        if site.z2pt5 is None:
+            site.z2pt5 = rcfg.z1pt0_to_z2pt5(site.z1pt0)        
+        
         site.arc_location = metadata["Forearc/Backarc for subduction events"]
         site.instrument_type = metadata["Type of Recording"]
         return site

--- a/smtk/parsers/simple_flatfile_parser_sara.py
+++ b/smtk/parsers/simple_flatfile_parser_sara.py
@@ -371,7 +371,7 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
             site.z1pt0 = rcfg.vs30_to_z1pt0_as08(site.vs30)
         if site.z2pt5 is None:
             site.z2pt5 = rcfg.z1pt0_to_z2pt5(site.z1pt0)
-        
+
         site.arc_location = metadata["Forearc/Backarc for subduction events"]
         site.instrument_type = metadata["Digital (D)/Analog (A) Recording"]
         return site

--- a/smtk/parsers/simple_flatfile_parser_sara.py
+++ b/smtk/parsers/simple_flatfile_parser_sara.py
@@ -183,7 +183,7 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
             "Along-width Hypocenter location " +
             "on the fault (fraction between 0 and 1)"])
         if f1 is None or f2 is None:
-            hypo_loc = None
+            hypo_loc = (0.5, 0.7)
         else:
             hypo_loc = (f1, f2)
 
@@ -225,9 +225,9 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
                 "strike": get_float(metadata['Nodal Plane 1 Strike (deg)']),
                 "dip": get_float(metadata['Nodal Plane 1 Dip (deg)']),
                 "rake": get_float(metadata['Nodal Plane 1 Rake Angle (deg)'])}
-        elif metadata['Fault Plane (1; 2; X)'] == 'X':
-            nodal_planes.nodal_plane_1 = {"strike": None,
-                                 "dip": None,
+        elif metadata['Fault Plane (1; 2; X)'] == 'X': # Set default vertical fault with strike to North
+            nodal_planes.nodal_plane_1 = {"strike": 0.0,
+                                 "dip": 90.0,
                                  "rake": None}
             nodal_planes.nodal_plane_2 = {"strike": None,
                                  "dip": None,

--- a/smtk/parsers/simple_flatfile_parser_sara.py
+++ b/smtk/parsers/simple_flatfile_parser_sara.py
@@ -370,7 +370,7 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
         if site.z1pt0 is None:
             site.z1pt0 = rcfg.vs30_to_z1pt0_as08(site.vs30)
         if site.z2pt5 is None:
-            site.z2pt5 = z1pt0_to_z2pt5(site.z1pt0)
+            site.z2pt5 = rcfg.z1pt0_to_z2pt5(site.z1pt0)
         
         site.arc_location = metadata["Forearc/Backarc for subduction events"]
         site.instrument_type = metadata["Digital (D)/Analog (A) Recording"]

--- a/smtk/parsers/simple_flatfile_parser_sara.py
+++ b/smtk/parsers/simple_flatfile_parser_sara.py
@@ -20,6 +20,9 @@ from smtk.parsers.base_database_parser import (get_float, get_int,
 # In order to define default fault dimension import scaling relationships
 from openquake.hazardlib.scalerel.strasser2010 import StrasserInterface, StrasserIntraslab
 from openquake.hazardlib.scalerel.wc1994 import WC1994
+from openquake.hazardlib.geo.mesh import Mesh
+import smtk.trellis.configure as rcfg
+from openquake.hazardlib.geo.point import Point
 
 HEADER_LIST = Set([
     'Record Sequence Number', 'EQID', 'Earthquake Name', 'Country', 'Year', 
@@ -114,10 +117,10 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
         wfid = metadata["Record Sequence Number"]
         # Event information
         event = self._parse_event_data(metadata)
-        # Distance Information
-        distances = self._parse_distance_data(metadata)
         # Site information
         site = self._parse_site_data(metadata)
+        # Distance Information
+        distances = self._parse_distance_data(event, site, metadata)
         # Components
         x_comp, y_comp, vertical = self._parse_processing_data(wfid, metadata)
         # Return record metadata
@@ -255,9 +258,22 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
                 "strike": get_float(metadata['Nodal Plane 1 Strike (deg)']),
                 "dip": get_float(metadata['Nodal Plane 1 Dip (deg)']),
                 "rake": get_float(metadata['Nodal Plane 1 Rake Angle (deg)'])}
-        elif metadata['Fault Plane (1; 2; X)'] == 'X': # Set default vertical fault with strike to North
-            nodal_planes.nodal_plane_1 = {"strike": 0.0,
-                                 "dip": 90.0,
+        elif metadata['Fault Plane (1; 2; X)'] == 'X':
+            # Check if values for strike or dip are given otherwise set strike=0 and dip=90
+            # and fill strike and dip for fault plane 1
+            # What can we do for rake?
+            strike = get_float(metadata['Nodal Plane 1 Strike (deg)'])
+            if strike is None:
+                strike = get_float(metadata['Nodal Plane 2 Strike (deg)'])
+            if strike is None:
+                strike = 0.0
+            dip = get_float(metadata['Nodal Plane 1 Dip (deg)'])
+            if dip is None:
+                dip = get_float(metadata['Nodal Plane 2 Dip (deg)'])
+            if dip is None:
+                dip = 90.0
+            nodal_planes.nodal_plane_1 = {"strike": strike,
+                                 "dip": dip,
                                  "rake": None}
             nodal_planes.nodal_plane_2 = {"strike": None,
                                  "dip": None,
@@ -270,16 +286,52 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
             mechanism_type=mech_type)
 
 
-    def _parse_distance_data(self, metadata):
+    def _parse_distance_data(self, event, site, metadata):
         """
         Read in the distance related metadata and return an instance of the
         :class: smtk.sm_database.RecordDistance
         """
+        # Compute various distance metrics
+        # Add calculation of Repi, Rhypo from event and station localizations (latitudes, longitudes, depth, elevation)?
+        target_site = Mesh(np.array(site.longitude), np.array(site.latitude), np.array(-site.altitude/1000.0))
+        # Warning ratio fixed to 1.5
+        ratio=1.5
+        surface_modeled = rcfg.create_planar_surface(Point(event.longitude, event.latitude, event.depth),
+                                             event.mechanism.nodal_planes.nodal_plane_1['strike'],
+                                             event.mechanism.nodal_planes.nodal_plane_1['dip'],
+                                             event.rupture.area,
+                                             ratio)
+        hypocenter = rcfg.get_hypocentre_on_planar_surface(surface_modeled, event.rupture.hypo_loc)
+        
+        # Rhypo
+        Rhypo = get_float(metadata["Hypocentral Distance (km)"])
+        if Rhypo is None:
+            Rhypo = hypocenter.distance_to_mesh(target_site)
+        # Repi
+        Repi = get_float(metadata["Epicentral Distance (km)"])
+        if Repi is None:
+            Repi= hypocenter.distance_to_mesh(target_site, with_depths=False)
+        # Rrup
+        Rrup = get_float(metadata["Rupture Distance (km)"])
+        if Rrup is None:
+            Rrup = surface_modeled.get_min_distance(target_site)
+        # Rjb
+        Rjb = get_float(metadata["Joyner-Boore Distance (km)"])
+        if Rjb is None:
+            Rjb = surface_modeled.get_joyner_boore_distance(target_site)
+        # Need to check if Rx and Ry0 are consistant with the other metrics when those are coming from the flatfile?
+        # Rx
+        Rx = surface_modeled.get_rx_distance(target_site)
+        # Ry0
+        Ry0 = surface_modeled.get_ry0_distance(target_site)
+        
         distance = RecordDistance(
-            get_float(metadata["Epicentral Distance (km)"]),
-            get_float(metadata["Hypocentral Distance (km)"]),
-            get_float(metadata["Joyner-Boore Distance (km)"]),
-            get_float(metadata["Rupture Distance (km)"]))
+            repi = Repi,
+            rhypo = Rhypo,
+            rjb = Rjb,
+            rrup = Rrup,
+            r_x = Rx,
+            ry0 = Ry0)
         distance.azimuth = get_float(metadata["Source to Site Azimuth (deg)"])
         distance.hanging_wall = get_float(metadata["FW/HW Indicator"])
         return distance
@@ -313,6 +365,13 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
         site.z1pt5 = None
         # site.z1pt5 = get_float(metadata["Z1.5 (m)"])
         site.z2pt5 = get_float(metadata["Z2.5 (m)"])
+        
+        # Implement default values for z1pt0 and z2pt5
+        if site.z1pt0 is None:
+            site.z1pt0 = rcfg.vs30_to_z1pt0_as08(site.vs30)
+        if site.z2pt5 is None:
+            site.z2pt5 = z1pt0_to_z2pt5(site.z1pt0)
+        
         site.arc_location = metadata["Forearc/Backarc for subduction events"]
         site.instrument_type = metadata["Digital (D)/Analog (A) Recording"]
         return site

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -663,7 +663,7 @@ class GroundMotionDatabase(object):
         if len(z1pt0) > 0:
             setattr(sctx, 'z1pt0', np.array(z1pt0))
         if len(z2pt5) > 0:
-            setattr(sctx, 'z2pt5', np.array(z1pt0))
+            setattr(sctx, 'z2pt5', np.array(z2pt5))
         if len(backarc) > 0:
             setattr(sctx, 'backarc', np.array(backarc))
         return sctx

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -660,7 +660,7 @@ class GroundMotionDatabase(object):
         if len(depths) > 0:
             setattr(sctx, 'depths', np.array(depths))
         if len(vs30_measured) > 0:
-            setattr(sctx, 'vs30measured', np.array(vs30))
+            setattr(sctx, 'vs30measured', np.array(vs30_measured))
         if len(z1pt0) > 0:
             setattr(sctx, 'z1pt0', np.array(z1pt0))
         if len(z2pt5) > 0:

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -648,9 +648,10 @@ class GroundMotionDatabase(object):
             if rup.site.z1pt0:
                 z1pt0.append(rup.site.z1pt0)
             if rup.site.z2pt5:
-                z1pt0.append(rup.site.z2pt5)
+                z2pt5.append(rup.site.z2pt5)
             if ("backarc" in dir(rup.site)) and rup.site.backarc:
                 backarc.append(rup.site.backarc)
+        print len(vs30), len(z1pt0)
         setattr(sctx, 'vs30', np.array(vs30))
         if len(longs) > 0:
             setattr(sctx, 'lons', np.array(longs))

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -688,20 +688,21 @@ class GroundMotionDatabase(object):
             # TODO Setting Rjb == Repi and Rrup == Rhypo when missing value
             # is a hack! Need feedback on how to fix
             # Set also rx=Repi if undefined
-            if rup.distance.rjb:
+            if rup.distance.rjb is not None:
                 rjb.append(rup.distance.rjb)
             else:
                 rjb.append(rup.distance.repi)
-            if rup.distance.rrup:
+            if rup.distance.rrup is not None:
                 rrup.append(rup.distance.rrup)
             else:
                 rrup.append(rup.distance.rhypo)
-            if rup.distance.r_x:
+            if rup.distance.r_x is not None:
                 r_x.append(rup.distance.r_x)
             else:
                 r_x.append(rup.distance.repi)
-            if ("ry0" in dir(rup.distance)) and rup.distance.ry0:
+            if ("ry0" in dir(rup.distance)) and rup.distance.ry0 is not None:
                 ry0.append(rup.distance.ry0)
+        
         setattr(dctx, 'repi', np.array(repi))
         setattr(dctx, 'rhypo', np.array(rhypo))
         if len(rjb) > 0:

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -638,7 +638,10 @@ class GroundMotionDatabase(object):
             rup = self.records[idx_j]
             longs.append(rup.site.longitude)
             lats.append(rup.site.latitude)
-            depths.append(rup.site.altitude * -1.0E-3)
+            if rup.site.altitude:
+                depths.append(rup.site.altitude * -1.0E-3)
+            else:
+                depths.append(0.0)
             vs30.append(rup.site.vs30)
             if rup.site.vs30_measured:
                 vs30_measured.append(rup.site.vs30_measured)
@@ -654,7 +657,7 @@ class GroundMotionDatabase(object):
         if len(lats) > 0:
             setattr(sctx, 'lats', np.array(lats))
         if len(depths) > 0:
-            setattr(sctx, 'depths', np.array(lats))
+            setattr(sctx, 'depths', np.array(depths))
         if len(vs30_measured) > 0:
             setattr(sctx, 'vs30measured', np.array(vs30))
         if len(z1pt0) > 0:

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -643,15 +643,15 @@ class GroundMotionDatabase(object):
             else:
                 depths.append(0.0)
             vs30.append(rup.site.vs30)
-            if rup.site.vs30_measured:
+            if rup.site.vs30_measured is not None:
                 vs30_measured.append(rup.site.vs30_measured)
             if rup.site.z1pt0:
                 z1pt0.append(rup.site.z1pt0)
             if rup.site.z2pt5:
                 z2pt5.append(rup.site.z2pt5)
-            if ("backarc" in dir(rup.site)) and rup.site.backarc:
+            if ("backarc" in dir(rup.site)) and rup.site.backarc is not None:
                 backarc.append(rup.site.backarc)
-        print len(vs30), len(z1pt0)
+        
         setattr(sctx, 'vs30', np.array(vs30))
         if len(longs) > 0:
             setattr(sctx, 'lons', np.array(longs))

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -686,6 +686,7 @@ class GroundMotionDatabase(object):
             rhypo.append(rup.distance.rhypo)
             # TODO Setting Rjb == Repi and Rrup == Rhypo when missing value
             # is a hack! Need feedback on how to fix
+            # Set also rx=Repi if undefined
             if rup.distance.rjb:
                 rjb.append(rup.distance.rjb)
             else:
@@ -696,6 +697,8 @@ class GroundMotionDatabase(object):
                 rrup.append(rup.distance.rhypo)
             if rup.distance.r_x:
                 r_x.append(rup.distance.r_x)
+            else:
+                r_x.append(rup.distance.repi)
             if ("ry0" in dir(rup.distance)) and rup.distance.ry0:
                 ry0.append(rup.distance.ry0)
         setattr(dctx, 'repi', np.array(repi))
@@ -732,6 +735,12 @@ class GroundMotionDatabase(object):
                 rup.event.mechanism.nodal_planes.nodal_plane_1['dip'])
             setattr(rctx, 'rake',
                 rup.event.mechanism.nodal_planes.nodal_plane_1['rake'])
+        if not rctx.strike:
+            # Hake: Set strike to North
+            setattr(rctx, 'strike', 0.0)
+        if not rctx.dip:
+            # Hake: Set dip to 90.0
+            setattr(rctx, 'dip', 90.0)
         if not rctx.rake:
             rctx.rake = rup.event.mechanism.get_rake_from_mechanism_type()
         if rup.event.rupture:

--- a/smtk/trellis/configure.py
+++ b/smtk/trellis/configure.py
@@ -433,6 +433,7 @@ class GSIMRupture(object):
         setattr(rctx, 'dip', self.dip)
         setattr(rctx, 'rake', self.rake)
         setattr(rctx, 'ztor', self.ztor)
+        setattr(rctx, 'hypo_loc', None)
         setattr(rctx, 'hypo_depth', self.rupture.hypocenter.depth)
         setattr(rctx, 'hypo_lat', self.rupture.hypocenter.latitude)
         setattr(rctx, 'hypo_lon', self.rupture.hypocenter.longitude)

--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -20,7 +20,6 @@ import numpy as np
 from collections import Iterable, OrderedDict
 from math import floor, ceil
 from sets import Set
-import matplotlib
 import matplotlib.pyplot as plt
 from openquake.hazardlib import gsim, imt
 from openquake.hazardlib.scalerel.wc1994 import WC1994
@@ -38,12 +37,13 @@ PARAM_DICT = {'magnitudes': [],
               'dip': None,
               'rake': None,
               'ztor': None,
-              'hypocentre_location': (0.5, 0.5),
+              'hypo_loc': (0.5, 0.5),
               'msr': WC1994()}
 
 PLOT_UNITS = {'PGA': 'g',
-              'PGV': 'cm/s',
+              'PGV': 'cm/s/s',
               'SA': 'g',
+              'PGA': 'g',
               'IA': 'm/s',
               'CSV': 'g-sec',
               'RSD': 's',
@@ -56,10 +56,6 @@ DISTANCE_LABEL_MAP = {'repi': 'Epicentral Dist.',
                       'rx': 'Rx Dist.'}
 
 FIG_SIZE = (7, 5)
-
-# RESET Axes tick labels
-matplotlib.rc("xtick", labelsize=14)
-matplotlib.rc("ytick", labelsize=14)
 
 
 def _check_gsim_list(gsim_list):
@@ -278,7 +274,7 @@ class BaseTrellis(object):
         assert isinstance(rupture, GSIMRupture)
         magnitudes = [rupture.magnitude]
         sctx, rctx, dctx = rupture.get_gsim_contexts()
-        # Greate distances dictionary
+        # Create distances dictionary
         distances = {}
         for key in dctx.__slots__:
             distances[key] = getattr(dctx, key)
@@ -371,8 +367,8 @@ class MagnitudeIMTTrellis(BaseTrellis):
                         linewidth=2.0,
                         label=gmpe.__class__.__name__)
             self.lines.append(line)
-            ax.grid(True)
-            #ax.set_title(i_m, fontsize=12)
+            ax.grid()
+            ax.set_title(i_m, fontsize=12)
             ax.set_xlim(floor(self.magnitudes[0]), ceil(self.magnitudes[-1]))
             self._set_labels(i_m, ax)
      
@@ -380,12 +376,12 @@ class MagnitudeIMTTrellis(BaseTrellis):
             """
             Sets the labels on the specified axes
             """
-            ax.set_xlabel("Magnitude", fontsize=16)
+            ax.set_xlabel("Magnitude", fontsize=12)
             if 'SA(' in i_m:
                 units = PLOT_UNITS['SA']
             else:
                 units = PLOT_UNITS[i_m]
-            ax.set_ylabel("Median %s (%s)" % (i_m, units), fontsize=16)
+            ax.set_ylabel("Median %s (%s)" % (i_m, units), fontsize=12)
         
 
     def get_ground_motion_values(self):
@@ -439,8 +435,8 @@ class MagnitudeSigmaIMTTrellis(MagnitudeIMTTrellis):
                             linewidth=2.0,
                             label=gmpe.__class__.__name__)
             self.lines.append(line)
-            ax.grid(True)
-            #ax.set_title(i_m, fontsize=12)
+            ax.grid()
+            ax.set_title(i_m, fontsize=12)
             ax.set_xlim(floor(self.magnitudes[0]), ceil(self.magnitudes[-1]))
             self._set_labels(i_m, ax)
     
@@ -473,8 +469,8 @@ class MagnitudeSigmaIMTTrellis(MagnitudeIMTTrellis):
         """
         Sets the axes labels
         """
-        ax.set_xlabel("Magnitude", fontsize=16)
-        ax.set_ylabel(self.stddevs + " Std. Dev.", fontsize=16)
+        ax.set_xlabel("Magnitude", fontsize=12)
+        ax.set_ylabel(self.stddevs + " Std. Dev.", fontsize=12)
         
     
 class DistanceIMTTrellis(MagnitudeIMTTrellis):
@@ -530,8 +526,8 @@ class DistanceIMTTrellis(MagnitudeIMTTrellis):
                 max_x = distance_vals[-1]
 
             self.lines.append(line)
-            ax.grid(True)
-            #ax.set_title(i_m, fontsize=12)
+            ax.grid()
+            ax.set_title(i_m, fontsize=12)
             
             ax.set_xlim(min_x, max_x)
             self._set_labels(i_m, ax)
@@ -542,12 +538,12 @@ class DistanceIMTTrellis(MagnitudeIMTTrellis):
             Sets the labels on the specified axes
             """
             ax.set_xlabel("%s (km)" % DISTANCE_LABEL_MAP[self.distance_type],
-                          fontsize=16)
+                          fontsize=12)
             if 'SA(' in i_m:
                 units = PLOT_UNITS['SA']
             else:
                 units = PLOT_UNITS[i_m]
-            ax.set_ylabel("Median %s (%s)" % (i_m, units), fontsize=16)
+            ax.set_ylabel("Median %s (%s)" % (i_m, units), fontsize=12)
 
 
 class DistanceSigmaIMTTrellis(DistanceIMTTrellis):
@@ -616,8 +612,8 @@ class DistanceSigmaIMTTrellis(DistanceIMTTrellis):
 
 
             self.lines.append(line)
-            ax.grid(True)
-            #ax.set_title(i_m, fontsize=12)
+            ax.grid()
+            ax.set_title(i_m, fontsize=12)
             
             ax.set_xlim(min_x, max_x)
             self._set_labels(i_m, ax)
@@ -628,8 +624,8 @@ class DistanceSigmaIMTTrellis(DistanceIMTTrellis):
         Sets the labels on the specified axes
         """
         ax.set_xlabel("%s (km)" % DISTANCE_LABEL_MAP[self.distance_type],
-                      fontsize=16)
-        ax.set_ylabel(self.stddevs + " Std. Dev.", fontsize=16)
+                      fontsize=12)
+        ax.set_ylabel(self.stddevs + " Std. Dev.", fontsize=12)
 
 
 class MagnitudeDistanceSpectraTrellis(MagnitudeIMTTrellis):
@@ -726,7 +722,7 @@ class MagnitudeDistanceSpectraTrellis(MagnitudeIMTTrellis):
             #                10.0 ** ceil(np.log10(periods[-1])))
             #else:
             ax.set_xlim(periods[0], periods[-1])
-            ax.grid(True)
+            ax.grid()
             self._set_labels(i_m, ax)
 
 
@@ -794,7 +790,7 @@ class MagnitudeDistanceSpectraSigmaTrellis(MagnitudeDistanceSpectraTrellis):
             #                10.0 ** ceil(np.log10(periods[-1])))
             #else:
             ax.set_xlim(periods[0], periods[-1])
-            ax.grid(True)
+            ax.grid()
             self._set_labels(i_m, ax)
 
     def get_ground_motion_values(self):
@@ -827,5 +823,5 @@ class MagnitudeDistanceSpectraSigmaTrellis(MagnitudeDistanceSpectraTrellis):
         """
         Sets the labels on the specified axes
         """
-        ax.set_xlabel("Period (s)", fontsize=16)
-        ax.set_ylabel("%s Std. Dev." % self.stddevs, fontsize=16)
+        ax.set_xlabel("Period (s)", fontsize=12)
+        ax.set_ylabel("%s Std. Dev." % self.stddevs, fontsize=12)


### PR DESCRIPTION
The flatfile parser v6 and v9 (sara) have been in order to set defaults values to fault orientation and dimensions (through virtual fault) in order to compute any distance metric. Default values for z1pt0 and z2pt5 are also computed within the parsers.
With this modifications one can run the residual analysis using recent GMPEs (NGA like) which need a lot of input parameters.