### PR TITLE
Modify parsers such that distances are stored as floats and not lists.

### DIFF
--- a/smtk/parsers/simple_flatfile_parser.py
+++ b/smtk/parsers/simple_flatfile_parser.py
@@ -259,12 +259,12 @@ class SimpleFlatfileParser(SMDatabaseReader):
         Ry0 = surface_modeled.get_ry0_distance(target_site)
         
         distance = RecordDistance(
-            repi = Repi,
-            rhypo = Rhypo,
-            rjb = Rjb,
-            rrup = Rrup,
-            r_x = Rx,
-            ry0 = Ry0)
+            repi = float(Repi),
+            rhypo = float(Rhypo),
+            rjb = float(Rjb),
+            rrup = float(Rrup),
+            r_x = float(Rx),
+            ry0 = float(Ry0))
         distance.azimuth = get_float(metadata["Source to Site Azimuth (deg)"])
         distance.hanging_wall = get_float(metadata["FW/HW Indicator"])
 #        distance = RecordDistance(

--- a/smtk/parsers/simple_flatfile_parser_sara.py
+++ b/smtk/parsers/simple_flatfile_parser_sara.py
@@ -339,12 +339,12 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
         Ry0 = surface_modeled.get_ry0_distance(target_site)
         
         distance = RecordDistance(
-            repi = Repi,
-            rhypo = Rhypo,
-            rjb = Rjb,
-            rrup = Rrup,
-            r_x = Rx,
-            ry0 = Ry0)
+            repi = float(Repi),
+            rhypo = float(Rhypo),
+            rjb = float(Rjb),
+            rrup = float(Rrup),
+            r_x = float(Rx),
+            ry0 = float(Ry0))
         distance.azimuth = get_float(metadata["Source to Site Azimuth (deg)"])
         distance.hanging_wall = get_float(metadata["FW/HW Indicator"])
         return distance


### PR DESCRIPTION
For some reason, the distances rjb, rrup, rx and ry0 were stored as lists of single numbers for each record when executing the parsers, which ended up in having lists of lists when using the db.get_context method.