### PR TITLE
Removes nrmllib dependency plus typo fixes

### DIFF
--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -697,7 +697,7 @@ class GroundMotionDatabase(object):
             if rup.distance.r_x is not None:
                 r_x.append(rup.distance.r_x)
             else:
-                r_x.append(rup.distance.epi)
+                r_x.append(rup.distance.repi)
             if ("ry0" in dir(rup.distance)) and rup.distance.ry0 is not None:
                 ry0.append(rup.distance.ry0)
         setattr(dctx, 'repi', np.array(repi))
@@ -743,7 +743,7 @@ class GroundMotionDatabase(object):
         if rup.event.rupture:
             setattr(rctx, 'ztor', rup.event.rupture.depth)
             setattr(rctx, 'width', rup.event.rupture.width)
-            setattr(rctx, 'hypo_loc', rup.event.rupture.hypo_loc)
+            #setattr(rctx, 'hypo_loc', rup.event.rupture.hypo_loc)
         setattr(rctx, 'hypo_depth', rup.event.depth)
         setattr(rctx, 'hypo_lat', rup.event.latitude)
         setattr(rctx, 'hypo_lon', rup.event.longitude)

--- a/smtk/strong_motion_selector.py
+++ b/smtk/strong_motion_selector.py
@@ -358,6 +358,6 @@ class SMRecordSelector(object):
         """
         idx = []
         for iloc, record in enumerate(self.database.records):
-            if record.average_lup and (record.average.lup >= lup):
+            if record.average_lup and (record.average_lup >= lup):
                 idx.append(iloc)
         return self.select_records(idx, as_db)


### PR DESCRIPTION
Removes the dependency on openquake.nrmllib for reading in the rupture model in the conditional gmfs tools. Replaced with openquake.commonlib parser for the rupture file

Fixes the typos noted in this PR: https://github.com/GEMScienceTools/gmpe-smtk/pull/27