### PR TITLE
Correct unit of z2pt5

### DIFF
--- a/smtk/parsers/simple_flatfile_parser_sara.py
+++ b/smtk/parsers/simple_flatfile_parser_sara.py
@@ -411,7 +411,8 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
         site.z1pt0 = get_float(metadata["Z1 (m)"])
         site.z1pt5 = None
         # site.z1pt5 = get_float(metadata["Z1.5 (m)"])
-        site.z2pt5 = get_float(metadata["Z2.5 (m)"])
+        # Need to convert z2pt5 from m to km
+        site.z2pt5 = get_float(metadata["Z2.5 (m)"])/1000.0
         # Implement default values for z1pt0 and z2pt5
         if site.z1pt0 is None:
             site.z1pt0 = rcfg.vs30_to_z1pt0_as08(site.vs30)

--- a/smtk/parsers/simple_flatfile_parser_sara.py
+++ b/smtk/parsers/simple_flatfile_parser_sara.py
@@ -417,7 +417,7 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
             site.z1pt0 = rcfg.vs30_to_z1pt0_as08(site.vs30)
         if site.z2pt5 is None:
             site.z2pt5 = rcfg.z1pt0_to_z2pt5(site.z1pt0)        
-        else
+        else:
             # Need to convert z2pt5 from m to km
             site.z2pt5 = site.z2pt5/1000.0
         if "Backarc" in metadata["Forearc/Backarc for subduction events"]:

--- a/smtk/parsers/simple_flatfile_parser_sara.py
+++ b/smtk/parsers/simple_flatfile_parser_sara.py
@@ -411,13 +411,15 @@ class SimpleFlatfileParserV9(SMDatabaseReader):
         site.z1pt0 = get_float(metadata["Z1 (m)"])
         site.z1pt5 = None
         # site.z1pt5 = get_float(metadata["Z1.5 (m)"])
-        # Need to convert z2pt5 from m to km
-        site.z2pt5 = get_float(metadata["Z2.5 (m)"])/1000.0
+        site.z2pt5 = get_float(metadata["Z2.5 (m)"])
         # Implement default values for z1pt0 and z2pt5
         if site.z1pt0 is None:
             site.z1pt0 = rcfg.vs30_to_z1pt0_as08(site.vs30)
         if site.z2pt5 is None:
             site.z2pt5 = rcfg.z1pt0_to_z2pt5(site.z1pt0)        
+        else
+            # Need to convert z2pt5 from m to km
+            site.z2pt5 = site.z2pt5/1000.0
         if "Backarc" in metadata["Forearc/Backarc for subduction events"]:
             site.backarc = True
         site.instrument_type = metadata["Digital (D)/Analog (A) Recording"]


### PR DESCRIPTION
There was an inconsistency in the unit of z2pt5 in the parser in meters when read directly from the flatfile and in kilometers when converted from z1pt0.