### PR TITLE
Various fixes and features (Dec 2016)

### DIFF
--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -529,6 +529,7 @@ class Component(object):
         self.id = waveform_id
         self.orientation = orientation
         self.lup = longest_period
+        self.sup = None
         self.filter = waveform_filter
         self.baseline = baseline
         self.ims = ims
@@ -595,6 +596,20 @@ class GroundMotionRecord(object):
         self.datafile = None
         self.misc = None
 
+    def get_azimuth(self):
+        """
+        If the azimuth is missing, returns the epicentre to station azimuth
+        """
+        if self.distance.azimuth:
+            return self.distance.azimuth
+        else:
+            self.distance.azimuth = geodetic.azimuth(
+                self.event.longitude,
+                self.event.latitude,
+                self.site.longitude,
+                self.site.latitude)
+        return self.distance.azimuth
+
 
 class GroundMotionDatabase(object):
     """
@@ -625,6 +640,27 @@ class GroundMotionDatabase(object):
         Returns number of records
         """
         return len(self.records)
+
+    def __len__(self):
+        """
+        Returns the number of records
+        """
+        return len(self.records)
+
+    def __iter__(self):
+        """
+        Iterate of the records
+        """
+        for record in self.records:
+            yield record
+
+    def __repr__(self):
+        """
+        String with database ID and name
+        """
+        return "{:s} - ID({:s}) - Name ({:s})".format(self.__class__.__name__,
+                                                      self.id,
+                                                      self.name)
 
     def get_contexts(self, nodal_plane_index=1):
         """


### PR DESCRIPTION
Recent application of the GMPE-SMTK in a project identified the following bugs/features needed:

1. Support for trellis plotting and residual calculations when GMPEs are defined in the form of tables. These should be input as strings in the gmpe_list as follows:
`GMPETable(gmpe_table='path/to/my_gmpe_table.hdf5')`

The key will appear as `my_gmpe_table` in the plots (so don't re-use the same filename for different models). Seemingly, this requires that the GMPE table hdf5 file is placed in a directory at at the same level or lower than that of the invoking script/notebook - an OpenQuake issue.

2. The inter-event residual term, whilst being calculated correctly for each record, is being biased with respect to the evaluation statistics in certain cases. The problem originates from the fact that some GMPEs have a site-dependent inter-event residual by virtue of the error propagation in the within-event variance (examples include Chiou & Youngs, 2008; 2014), whilst for others it is independent of site and all sites share the same inter-event residual. In the latter case this means that certain values are repeated frequently in the resulting residual statistics. This behaviour is modified now so that only unique values are retained for the statistics.

3. Bug in the rupture configuration for trellis plotting when the rupture distance is small now fixed

4. New attributes to the database

5. Modified the cycling of colours and lines for the GMPE trellis plots (now cycles over 21 line-colour combinations before repetition).