### PR TITLE
Revision of Trellis Plots and addition of json exporters

### DIFF
--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -572,7 +572,8 @@ class MagnitudeIMTTrellis(BaseTrellis):
                         iml_to_list.append(val)
                 gmv_dict["figures"][imt].append((gsim, iml_to_list))
             gmv_dict["figures"][imt] = OrderedDict(gmv_dict["figures"][imt])
-        json.dump(gmv_dict, open(filename, "w"))
+        #json.dump(gmv_dict, open(filename, "w"))
+        json.dumps(gmv_dict)
 
     def get_ground_motion_values(self):
         """
@@ -900,7 +901,8 @@ class DistanceIMTTrellis(MagnitudeIMTTrellis):
                 imt_dict["yvalues"].append((gsim, data))
             imt_dict["yvalues"] = OrderedDict(imt_dict["yvalues"])
             gmv_dict["figures"][imt] = imt_dict
-        json.dump(gmv_dict, open(filename, "w"))
+        #json.dump(gmv_dict, open(filename, "w"))
+        json.dumps(gmv_dict)
 
     def pretty_print(self, filename=None, sep=","):
         """
@@ -1405,7 +1407,8 @@ class MagnitudeDistanceSpectraTrellis(BaseTrellis):
                         else:
                             gmv_dict["figures"][pos_name]["yvalues"][gsim].\
                                 append(None)
-        json.dump(gmv_dict, open(filename, "w"))
+        #json.dump(gmv_dict, open(filename, "w"))
+        json.dumps(gmv_dict)
 
     def _get_ylabel(self, i_m):
         """

--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -572,8 +572,7 @@ class MagnitudeIMTTrellis(BaseTrellis):
                         iml_to_list.append(val)
                 gmv_dict["figures"][imt].append((gsim, iml_to_list))
             gmv_dict["figures"][imt] = OrderedDict(gmv_dict["figures"][imt])
-        #json.dump(gmv_dict, open(filename, "w"))
-        json.dumps(gmv_dict)
+        return json.dumps(gmv_dict)
 
     def get_ground_motion_values(self):
         """
@@ -901,8 +900,7 @@ class DistanceIMTTrellis(MagnitudeIMTTrellis):
                 imt_dict["yvalues"].append((gsim, data))
             imt_dict["yvalues"] = OrderedDict(imt_dict["yvalues"])
             gmv_dict["figures"][imt] = imt_dict
-        #json.dump(gmv_dict, open(filename, "w"))
-        json.dumps(gmv_dict)
+        return json.dumps(gmv_dict)
 
     def pretty_print(self, filename=None, sep=","):
         """
@@ -1407,8 +1405,7 @@ class MagnitudeDistanceSpectraTrellis(BaseTrellis):
                         else:
                             gmv_dict["figures"][pos_name]["yvalues"][gsim].\
                                 append(None)
-        #json.dump(gmv_dict, open(filename, "w"))
-        json.dumps(gmv_dict)
+        return json.dumps(gmv_dict)
 
     def _get_ylabel(self, i_m):
         """

--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -21,7 +21,7 @@
 Sets up a simple rupture-site configuration to allow for physical comparison
 of GMPEs 
 '''
-import sys, re, os
+import sys, re, os, json
 import numpy as np
 from collections import Iterable, OrderedDict
 from itertools import cycle
@@ -32,20 +32,25 @@ import matplotlib
 from copy import deepcopy
 import matplotlib.pyplot as plt
 from openquake.hazardlib import gsim, imt
+from openquake.hazardlib.gsim.base import (RuptureContext,
+                                           DistancesContext,
+                                           SitesContext)
 from openquake.hazardlib.gsim.gsim_table import GMPETable
 from openquake.hazardlib.scalerel.wc1994 import WC1994
 from smtk.sm_utils import _save_image, _save_image_tight
 import smtk.trellis.trellis_utils as utils
-from smtk.trellis.configure import GSIMRupture
+from smtk.trellis.configure import GSIMRupture, DEFAULT_POINT
 
 # Default - defines a 21 color and line-type cycle
 matplotlib.rcParams["axes.prop_cycle"] = \
     cycler(u'color', [u'b', u'g', u'r', u'c', u'm', u'y', u'k',
                       u'b', u'g', u'r', u'c', u'm', u'y', u'k',
+                      u'b', u'g', u'r', u'c', u'm', u'y', u'k',
                       u'b', u'g', u'r', u'c', u'm', u'y', u'k']) +\
     cycler(u'linestyle', ["-", "-", "-", "-", "-", "-", "-",
                           "--", "--", "--", "--", "--", "--", "--",
-                          "-.", "-.", "-.", "-.", "-.", "-.", "-."])
+                          "-.", "-.", "-.", "-.", "-.", "-.", "-.",
+                          ":", ":", ":", ":", ":", ":", ":"])
 
 # Get a list of the available GSIMs
 AVAILABLE_GSIMS = gsim.get_available_gsims()
@@ -67,6 +72,7 @@ PARAM_DICT = {'magnitudes': [],
 PLOT_UNITS = {'PGA': 'g',
               'PGV': 'cm/s',
               'SA': 'g',
+              'SD': 'cm',
               'IA': 'm/s',
               'CSV': 'g-sec',
               'RSD': 's',
@@ -241,8 +247,6 @@ class BaseTrellis(object):
         self.ylim = kwargs["ylim"]
         self.legend_fontsize = kwargs["legend_fontsize"]
         self.ncol = kwargs["ncol"]
-        self.create_plot()
-
 
     def _preprocess_distances(self):
         """
@@ -375,11 +379,18 @@ class BaseTrellis(object):
         return cls(magnitudes, distances, gsims, imts, params, stddevs,
                    rupture=rupture, **kwargs)
 
-    def create_plot(self):
+    def plot(self):
         """
         Creates the plot!
         """
         raise NotImplementedError("Cannot create plot of base class!")
+
+    def _get_ylabel(self, imt):
+        """
+        Returns the label for plotting on a y axis
+        """
+        raise NotImplementedError
+
 
 
 class MagnitudeIMTTrellis(BaseTrellis):
@@ -399,17 +410,70 @@ class MagnitudeIMTTrellis(BaseTrellis):
         super(MagnitudeIMTTrellis, self).__init__(magnitudes, distances, gsims,
             imts, params, stddevs, **kwargs)
 
-    def create_plot(self):
+    @classmethod
+    def from_rupture_model(cls, properties, magnitudes, distance, gsims, imts,
+                           stddevs='Total', **kwargs):
+        """
+        Implements the magnitude trellis from a dictionary of properties,
+        magnitudes and distance
+        """
+        kwargs.setdefault('filename', None)
+        kwargs.setdefault('filetype', "png")
+        kwargs.setdefault('dpi', 300)
+        kwargs.setdefault('plot_type', "loglog")
+        kwargs.setdefault('distance_type', "rjb")
+        kwargs.setdefault('xlim', None)
+        kwargs.setdefault('ylim', None)
+        # Properties
+        properties.setdefault("tectonic_region", "Active Shallow Crust")
+        properties.setdefault("rake", 0.)
+        properties.setdefault("ztor", 0.)
+        properties.setdefault("strike", 0.)
+        properties.setdefault("msr", WC1994())
+        properties.setdefault("initial_point", DEFAULT_POINT)
+        properties.setdefault("hypocentre_location", None)
+        properties.setdefault("line_azimuth", 90.)
+        properties.setdefault("origin_point", (0.5, 0.5))
+        properties.setdefault("vs30measured", True)
+        properties.setdefault("z1pt0", None)
+        properties.setdefault("z2pt5", None)
+        properties.setdefault("backarc", False)
+        properties.setdefault("distance_type", "rrup")
+        # Define a basic rupture configuration
+        rup = GSIMRupture(magnitudes[0], properties["dip"],
+                          properties["aspect"], properties["tectonic_region"],
+                          properties["rake"], properties["ztor"],
+                          properties["strike"], properties["msr"],
+                          properties["initial_point"],
+                          properties["hypocentre_location"])
+        # Add the target sites
+        _ = rup.get_target_sites_point(distance, properties['distance_type'],
+                                       properties["vs30"],
+                                       properties["line_azimuth"],
+                                       properties["origin_point"],
+                                       properties["vs30measured"],
+                                       properties["z1pt0"],
+                                       properties["z2pt5"],
+                                       properties["backarc"])
+        # Get the contexts
+        sctx, rctx, dctx = rup.get_gsim_contexts()
+        # Create an equivalent 'params' dictionary by merging the site and
+        # rupture properties
+        sctx.__dict__.update(rctx.__dict__)
+        for val in dctx.__dict__:
+            if getattr(dctx, val) is not None:
+                setattr(dctx, val, getattr(dctx, val)[0])
+        return cls(magnitudes, dctx.__dict__, gsims, imts, sctx.__dict__,
+                   **kwargs)
+
+    def plot(self):
         """
         Creates the trellis plot!
         """
         # Determine the optimum number of rows and columns
         nrow, ncol = utils.best_subplot_dimensions(len(self.imts))
         # Get means and standard deviations
-        if self.rupture:
-            gmvs = self.get_ground_motion_values_from_rupture()
-        else:
-            gmvs = self.get_ground_motion_values()
+        gmvs = self.get_ground_motion_values()
         fig = plt.figure(figsize=self.figure_size)
         fig.set_tight_layout(True)
         row_loc = 0
@@ -428,14 +492,13 @@ class MagnitudeIMTTrellis(BaseTrellis):
         # Add legend
         lgd = plt.legend(self.lines,
                          self.labels,
-                         loc=2,
-                         bbox_to_anchor=(1.05, 1.),
+                         loc=3,
+                         bbox_to_anchor=(1.1, 0.),
                          fontsize=self.legend_fontsize,
                          ncol=self.ncol)
         _save_image_tight(fig, lgd, self.filename, self.filetype, self.dpi)
         plt.show()
 
-       
     def _build_plot(self, ax, i_m, gmvs):
         """
         Plots the lines for a given axis
@@ -449,7 +512,6 @@ class MagnitudeIMTTrellis(BaseTrellis):
         self.labels = []
         self.lines = []
         for gmpe in self.gsims:
-            #self.labels.append(gmpe.__class__.__name__)
             gmpe_name = _get_gmpe_name(gmpe)
             self.labels.append(gmpe_name)
             line, = ax.semilogy(self.magnitudes,
@@ -470,16 +532,47 @@ class MagnitudeIMTTrellis(BaseTrellis):
             self._set_labels(i_m, ax)
      
     def _set_labels(self, i_m, ax):
-            """
-            Sets the labels on the specified axes
-            """
-            ax.set_xlabel("Magnitude", fontsize=16)
-            if 'SA(' in i_m:
-                units = PLOT_UNITS['SA']
-            else:
-                units = PLOT_UNITS[i_m]
-            ax.set_ylabel("Mean %s (%s)" % (i_m, units), fontsize=16)
-        
+        """
+        Sets the labels on the specified axes
+        """
+        ax.set_xlabel("Magnitude", fontsize=16)
+        ax.set_ylabel(self._get_ylabel(i_m), fontsize=16)
+
+    def _get_ylabel(self, i_m):
+        """
+        Return the y-label for the magnitude IMT trellis
+        """
+        if 'SA(' in i_m:
+            units = PLOT_UNITS['SA']
+        else:
+            units = PLOT_UNITS[i_m]
+        return "Mean {:s} ({:s})".format(i_m, units)
+
+    def to_json(self, filename):
+        """
+        Serializes the ground motion values to json
+        """
+        gmvs = self.get_ground_motion_values()
+        gmv_dict = OrderedDict([
+            ("xvalues", self.magnitudes.tolist()),
+            ("xlabel", "Magnitude")])
+        nvals = len(self.magnitudes)
+        gmv_dict["figures"] = OrderedDict([])
+        for imt in self.imts:
+            gmv_dict["figures"][imt] = [("ylabel", self._get_ylabel(imt))]
+            for gsim in gmvs:
+                if not len(gmvs[gsim][imt]):
+                    gmv_dict["figures"][imt] = [None for i in range(nvals)]
+                    continue
+                iml_to_list = []
+                for val in gmvs[gsim][imt].flatten().tolist():
+                    if np.isnan(val) or (val < 0.0):
+                        iml_to_list.append(None)
+                    else:
+                        iml_to_list.append(val)
+                gmv_dict["figures"][imt].append((gsim, iml_to_list))
+            gmv_dict["figures"][imt] = OrderedDict(gmv_dict["figures"][imt])
+        json.dump(gmv_dict, open(filename, "w"))
 
     def get_ground_motion_values(self):
         """
@@ -512,73 +605,6 @@ class MagnitudeIMTTrellis(BaseTrellis):
                         break
         return gmvs
 
-    def get_ground_motion_values_from_rupture(self):
-        """
-        """
-        gmvs = OrderedDict()
-        rctx, dctx, sctx = self._get_context_sets()                           
-        for gmpe in self.gsims:
-            gmpe_name = _get_gmpe_name(gmpe)
-            gmvs.update([(gmpe_name, {})])
-            for i_m in self.imts:
-                gmvs[gmpe_name][i_m] = np.zeros(
-                    [len(self.rctx), self.nsites], dtype=float)
-                for iloc, (rct, dct, sct) in enumerate(zip(rctx, dctx, sctx)):
-                    try:
-                        means, _ = gmpe.get_mean_and_stddevs(
-                            sct,
-                            rct,
-                            dct,
-                            imt.from_string(i_m),
-                            [self.stddevs])
-
-                        gmvs[gmpe_name][i_m][iloc, :] = \
-                            np.exp(means)
-                    except (KeyError, ValueError):
-                        gmvs[gmpe_name][i_m] = []
-                        break
-        return gmvs
-
-
-    def _get_context_sets(self):
-        """
-        When building from the rupture it is possible that it may be preferable
-        to re-build the contexts (e.g. for magnitude scaling).
-        """
-        # Build context sets 
-        rct = []
-        dct = []
-        sct = []
-        for rctx in self.rctx:
-            temp_rup = deepcopy(self.rupture)
-            # Update mag
-            temp_rup.mag = deepcopy(rctx.mag)
-            temp_rup.rupture = temp_rup.get_rupture()
-            temp_rup.target_sites = None
-            # Update target sites
-            if temp_rup.target_sites_config["TYPE"] == "Mesh":
-                _ = temp_rup.get_target_sites_mesh(
-                    *[temp_rup.target_sites_config[key] for key in
-                      ["RMAX", "SPACING", "VS30", "VS30MEASURED",
-                      "Z1.0", "Z2.5", "BACKARC"]])
-            elif temp_rup.target_sites_config["TYPE"] == "Line":
-                _ = temp_rup.get_target_sites_line(
-                    *[temp_rup.target_sites_config[key] for key in
-                    ["RMAX", "SPACING", "VS30", "AZIMUTH", "ORIGIN",
-                     "AS_LOG", "VS30MEASURED", "Z1.0", "Z2.5", "BACKARC"]])
-            else:
-                _ = temp_rup.get_target_sites_point(
-                    *[temp_rup.target_sites_config[key] for key in
-                     ["R", "RTYPE", "VS30", "AZIMUTH", "ORIGIN", 
-                     "VS30MEASURED", "Z1.0", "Z2.5", "BACKARC"]]) 
-            s_c, r_c, d_c = temp_rup.get_gsim_contexts()
-            rct.append(r_c)
-            dct.append(d_c)
-            sct.append(s_c)
-        return rct, dct, sct
- 
-
-
     def pretty_print(self, filename=None, sep=","):
         """
         Format the ground motion for printing to file or to screen
@@ -598,10 +624,7 @@ class MagnitudeIMTTrellis(BaseTrellis):
                                  for (key, val) in self.dctx.__dict__.items()])
         fid.write("Distances%s%s\n" % (sep, distance_str))
         # Loop over IMTs
-        if self.rupture:
-            gmvs = self.get_ground_motion_values_from_rupture()
-        else:
-            gmvs = self.get_ground_motion_values()
+        gmvs = self.get_ground_motion_values()
         for imt in self.imts:
             fid.write("%s\n" % imt)
             header_str = "Magnitude" + sep + sep.join([_get_gmpe_name(gsim)
@@ -719,13 +742,17 @@ class MagnitudeSigmaIMTTrellis(MagnitudeIMTTrellis):
                         break
         return gmvs
 
+    def _get_ylabel(self, i_m):
+        """
+        """
+        return self.stddevs + " Std. Dev. ({:s})".format(str(i_m))
+
     def _set_labels(self, i_m, ax):
         """
         Sets the axes labels
         """
         ax.set_xlabel("Magnitude", fontsize=16)
-        ax.set_ylabel(self.stddevs + " Std. Dev. ({:s})".format(str(i_m)),
-                      fontsize=16)
+        ax.set_ylabel(self._get_ylabel(i_m), fontsize=16)
     
     def _write_pprint_header_line(self, fid, sep=","):
         """
@@ -754,6 +781,40 @@ class DistanceIMTTrellis(MagnitudeIMTTrellis):
         super(DistanceIMTTrellis, self).__init__(magnitudes, distances, gsims,
             imts, params, stddevs, **kwargs)
     
+    @classmethod
+    def from_rupture_model(cls, rupture, gsims, imts, stddevs='Total',
+            **kwargs):
+        """
+        Constructs the Base Trellis Class from a rupture model
+        :param rupture:
+            Rupture as instance of the :class:
+            smtk.trellis.configure.GSIMRupture
+        """
+        kwargs.setdefault('filename', None)
+        kwargs.setdefault('filetype', "png")
+        kwargs.setdefault('dpi', 300)
+        kwargs.setdefault('plot_type', "loglog")
+        kwargs.setdefault('distance_type', "rjb")
+        kwargs.setdefault('xlim', None)
+        kwargs.setdefault('ylim', None)
+        assert isinstance(rupture, GSIMRupture)
+        magnitudes = [rupture.magnitude]
+        sctx, rctx, dctx = rupture.get_gsim_contexts()
+        # Create distances dictionary
+        distances = {}
+        for key in dctx._slots_:
+            distances[key] = getattr(dctx, key)
+        # Add all other parameters to the dictionary
+        params = {}
+        for key in rctx._slots_:
+            params[key] = getattr(rctx, key)
+        #for key in sctx.__slots__:
+        for key in sctx._slots_:
+        #for key in ['vs30', 'vs30measured', 'z1pt0', 'z2pt5']:
+            params[key] = getattr(sctx, key)
+        return cls(magnitudes, distances, gsims, imts, params, stddevs,
+                   **kwargs)
+
     def _build_plot(self, ax, i_m, gmvs):
         """
         Plots the lines for a given axis
@@ -802,18 +863,44 @@ class DistanceIMTTrellis(MagnitudeIMTTrellis):
                 ax.set_ylim(self.ylim[0], self.ylim[1])  
             self._set_labels(i_m, ax)
 
-        
     def _set_labels(self, i_m, ax):
-            """
-            Sets the labels on the specified axes
-            """
-            ax.set_xlabel("%s (km)" % DISTANCE_LABEL_MAP[self.distance_type],
-                          fontsize=16)
-            if 'SA(' in i_m:
-                units = PLOT_UNITS['SA']
-            else:
-                units = PLOT_UNITS[i_m]
-            ax.set_ylabel("Mean %s (%s)" % (i_m, units), fontsize=16)
+        """
+        Sets the labels on the specified axes
+        """
+        ax.set_xlabel("%s (km)" % DISTANCE_LABEL_MAP[self.distance_type],
+                      fontsize=16)
+        ax.set_ylabel(self._get_ylabel(i_m), fontsize=16)
+
+    def _get_ylabel(self, i_m):
+        """
+        Returns the y-label for the given IMT
+        """
+        if 'SA(' in i_m:
+            units = PLOT_UNITS['SA']
+        else:
+            units = PLOT_UNITS[i_m]
+        return "Mean {:s} ({:s})".format(i_m, units)
+
+    def to_json(self, filename):
+        """
+        Exports ground motion values to json
+        """
+        gmvs = self.get_ground_motion_values()
+        dist_label = "{:s} (km)".format(DISTANCE_LABEL_MAP[self.distance_type])
+        gmv_dict = OrderedDict([
+            ("xvalues", self.distances[self.distance_type].tolist()),
+            ("xlabel", dist_label)])
+        gmv_dict["figures"] = OrderedDict([])
+        for imt in self.imts:
+            imt_dict = OrderedDict([("ylabel", self._get_ylabel(imt)),
+                                    ("yvalues", [])])
+            for gsim in gmvs:
+                data  = [None if np.isnan(val) else val
+                         for val in gmvs[gsim][imt].flatten()]
+                imt_dict["yvalues"].append((gsim, data))
+            imt_dict["yvalues"] = OrderedDict(imt_dict["yvalues"])
+            gmv_dict["figures"][imt] = imt_dict
+        json.dump(gmv_dict, open(filename, "w"))
 
     def pretty_print(self, filename=None, sep=","):
         """
@@ -975,15 +1062,18 @@ class DistanceSigmaIMTTrellis(DistanceIMTTrellis):
                 
             self._set_labels(i_m, ax)
 
-        
+    def _get_ylabel(self, i_m):
+        """
+        """
+        return self.stddevs + " Std. Dev. ({:s})".format(str(i_m)) 
+
     def _set_labels(self, i_m, ax):
         """
         Sets the labels on the specified axes
         """
         ax.set_xlabel("%s (km)" % DISTANCE_LABEL_MAP[self.distance_type],
                       fontsize=16)
-        ax.set_ylabel(self.stddevs + " Std. Dev. ({:s})".format(str(i_m)),
-                      fontsize=16)
+        ax.set_ylabel(self._get_ylabel(i_m), fontsize=16)
 
     def _write_pprint_header_line(self, fid, sep=","):
         """
@@ -995,21 +1085,167 @@ class DistanceSigmaIMTTrellis(DistanceIMTTrellis):
                                      for (key, val) in self.params.items()]))
 
 
-class MagnitudeDistanceSpectraTrellis(MagnitudeIMTTrellis):
-    """
-
-    """
+class MagnitudeDistanceSpectraTrellis(BaseTrellis):
+    # In this case the preprocessor needs to be removed
     def __init__(self, magnitudes, distances, gsims, imts, params,
             stddevs="Total", **kwargs):
-        """ 
+        """
+        Builds the trellis plots for variation in response spectra with
+        magnitude and distance.
+
+        In this case the class is instantiated with a set of magnitudes
+        and a dictionary indicating the different distance types.
         """
         imts = ["SA(%s)" % i_m for i_m in imts]
 
         super(MagnitudeDistanceSpectraTrellis, self).__init__(magnitudes, 
-            distances, gsims, imts, params, stddevs, **kwargs)
+             distances, gsims, imts, params, stddevs, **kwargs)
     
+    def _preprocess_ruptures(self):
+        """
+        In this case properties such as the rupture depth and width may change
+        with the magnitude. Where this behaviour is desired the use feeds
+        the function with a list of RuptureContext instances, in which each
+        rupture context contains the information specific to that magnitude.
 
-    def create_plot(self):
+        If this behaviour is not desired then the pre-processing of the
+        rupture information proceeds as in the conventional case within the
+        base class
+        """
+        # If magnitudes was provided with a list of RuptureContexts
+        if all([isinstance(mag, RuptureContext)
+                for mag in self.magnitudes]):
+            # Get all required rupture attributes
+            self.rctx = [mag for mag in self.magnitudes]
+            for gmpe in self.gsims:
+                rup_params = [param
+                              for param in gmpe.REQUIRES_RUPTURE_PARAMETERS]
+                for rctx in self.rctx:
+                    for param in rup_params:
+                        if not param in rctx.__dict__:
+                            raise ValueError(
+                                "GMPE %s requires rupture parameter %s"
+                                % (_get_gmpe_name(gmpe), param))
+            return
+        # Otherwise instantiate in the conventional way
+        super(MagnitudeDistanceSpectraTrellis, self)._preprocess_ruptures()
+    
+    def _preprocess_distances(self):
+        """
+        In the case of distances one can pass either a dictionary containing
+        the distances, or a list of dictionaries each calibrated to a specific
+        magnitude (the list must be the same length as the number of
+        magnitudes)
+        """
+        if isinstance(self.distances, dict):
+            # Copy the same distances across
+            self.distances = [deepcopy(self.distances)
+                              for mag in self.magnitudes]
+        assert (len(self.distances) == len(self.magnitudes))
+        # Distances should be a list of dictionaries
+        self.dctx = []
+        required_distances = []
+        for gmpe in self.gsims:
+            gsim_distances = [dist for dist in gmpe.REQUIRES_DISTANCES]
+            for mag_distances in self.distances:
+                for dist in gsim_distances:
+                    if not dist in mag_distances.keys():
+                        raise ValueError('GMPE %s requires distance type %s'
+                                         % (_get_gmpe_name(gmpe), dist))
+
+                    if not dist in required_distances:
+                        required_distances.append(dist)
+ 
+        for distance in self.distances:
+            dctx = gsim.base.DistancesContext()
+            dist_check = False
+            for dist in required_distances:
+                if dist_check and not (len(distance[dist]) == self.nsites):
+                    raise ValueError("Distances arrays not equal length!")
+                else:
+                    self.nsites = len(distance[dist])
+                    dist_check = True
+                setattr(dctx, dist, distance[dist])
+            self.dctx.append(dctx)
+
+    @classmethod
+    def from_rupture_model(cls, properties, magnitudes, distances,
+                           gsims, imts, stddevs='Total', **kwargs):
+        """
+        Constructs the Base Trellis Class from a rupture model
+        :param dict properties:
+            Properties of the rupture and sites, including (* indicates
+            required): *dip, *aspect, tectonic_region, rake, ztor, strike,
+                       msr, initial_point, hypocentre_location, distance_type,
+                       vs30, line_azimuth, origin_point, vs30measured, z1pt0,
+                       z2pt5, backarc
+        :param list magnitudes:
+            List of magnitudes
+        :param list distances:
+            List of distances (the distance type should be specified in the
+            properties dict - rrup, by default)
+        """
+        kwargs.setdefault('filename', None)
+        kwargs.setdefault('filetype', "png")
+        kwargs.setdefault('dpi', 300)
+        kwargs.setdefault('plot_type', "loglog")
+        kwargs.setdefault('distance_type', "rjb")
+        kwargs.setdefault('xlim', None)
+        kwargs.setdefault('ylim', None)
+        # Defaults for the properties of the rupture and site configuration
+        properties.setdefault("tectonic_region", "Active Shallow Crust")
+        properties.setdefault("rake", 0.)
+        properties.setdefault("ztor", 0.)
+        properties.setdefault("strike", 0.)
+        properties.setdefault("msr", WC1994())
+        properties.setdefault("initial_point", DEFAULT_POINT)
+        properties.setdefault("hypocentre_location", None)
+        properties.setdefault("line_azimuth", 90.)
+        properties.setdefault("origin_point", (0.5, 0.5))
+        properties.setdefault("vs30measured", True)
+        properties.setdefault("z1pt0", None)
+        properties.setdefault("z2pt5", None)
+        properties.setdefault("backarc", False)
+        properties.setdefault("distance_type", "rrup")
+        distance_dicts = []
+        rupture_dicts = []
+        for magnitude in magnitudes:
+            # Generate the rupture for the specific magnitude
+            rup = GSIMRupture(magnitude, properties["dip"],
+                              properties["aspect"],
+                              properties["tectonic_region"],
+                              properties["rake"], properties["ztor"],
+                              properties["strike"], properties["msr"],
+                              properties["initial_point"],
+                              properties["hypocentre_location"])
+            distance_dict = None
+            for distance in distances:
+                # Define the target sites with respect to the rupture
+                _ = rup.get_target_sites_point(distance,
+                                               properties["distance_type"],
+                                               properties["vs30"],
+                                               properties["line_azimuth"],
+                                               properties["origin_point"],
+                                               properties["vs30measured"],
+                                               properties["z1pt0"],
+                                               properties["z2pt5"],
+                                               properties["backarc"])
+                sctx, rctx, dctx = rup.get_gsim_contexts()
+                if not distance_dict:   
+                    distance_dict = []
+                    for key, val in dctx.__dict__.iteritems():
+                        distance_dict.append((key, val))
+                    distance_dict = dict(distance_dict)
+                else:
+                    for key, val in dctx.__dict__.iteritems():
+                        distance_dict[key] = np.hstack([
+                                distance_dict[key], val])
+            distance_dicts.append(distance_dict)
+            rupture_dicts.append(rctx)
+        return cls(rupture_dicts, distance_dicts, gsims, imts, properties,
+                   stddevs, **kwargs)
+
+    def plot(self):
         """
         Create plot!
         """
@@ -1028,13 +1264,41 @@ class MagnitudeDistanceSpectraTrellis(MagnitudeIMTTrellis):
         # Add legend
         lgd = plt.legend(self.lines,
                          self.labels,
-                         loc=2,
-                         bbox_to_anchor=(1.1, 1.),
-                         ncol=self.ncol)
+                         loc=3.,
+                         bbox_to_anchor=(1.1, 0.0),
+                         fontsize=self.legend_fontsize)
+
         _save_image_tight(fig, lgd, self.filename, self.filetype, self.dpi)
         plt.show()
-
-
+    
+    def get_ground_motion_values(self):
+        """
+        Runs the GMPE calculations to retreive ground motion values
+        :returns:
+            Nested dictionary of values
+            {'GMPE1': {'IM1': , 'IM2': },
+             'GMPE2': {'IM1': , 'IM2': }}
+        """
+        gmvs = OrderedDict()
+        for gmpe in self.gsims:
+            gmpe_name = _get_gmpe_name(gmpe)
+            gmvs.update([(gmpe_name, {})])
+            for i_m in self.imts:
+                gmvs[gmpe_name][i_m] = np.zeros(
+                    [len(self.rctx), self.nsites], dtype=float)
+                for iloc, (rct, dct) in enumerate(zip(self.rctx, self.dctx)):
+                    try:
+                        means, _ = gmpe.get_mean_and_stddevs(
+                            self.sctx, rct, dct,
+                            imt.from_string(i_m),
+                            [self.stddevs])
+                       
+                        gmvs[gmpe_name][i_m][iloc, :] = \
+                            np.exp(means)
+                    except (KeyError, ValueError):
+                        gmvs[gmpe_name][i_m] = []
+                        break
+        return gmvs
 
     def _build_plot(self, ax, gmvs, rloc, cloc):
         """
@@ -1048,8 +1312,6 @@ class MagnitudeDistanceSpectraTrellis(MagnitudeIMTTrellis):
         """
         self.labels = []
         self.lines = []
-        #periods = np.array([imt.from_string(i_m).period
-        #                    for i_m in self.imts])
         max_period = 0.0
         min_period = np.inf
         for gmpe in self.gsims:
@@ -1073,20 +1335,18 @@ class MagnitudeDistanceSpectraTrellis(MagnitudeIMTTrellis):
             if self.plot_type == "loglog":
                 line, = ax.loglog(periods,
                                   spec,
-                                  #"-",
                                   linewidth=2.0,
                                   label=gmpe_name)
             else:
                 line, = ax.semilogy(periods,
                                     spec,
-                                    #"-",
                                     linewidth=2.0,
                                     label=gmpe_name)
             # On the top row, add the distance as a title
             if rloc == 0:
-                ax.set_title("%s = %9.3f (km)" %(
+                ax.set_title("%s = %9.1f (km)" %(
                     self.distance_type,
-                    self.distances[self.distance_type][cloc]),
+                    self.distances[rloc][self.distance_type][cloc]),
                     fontsize=14)
             # On the last column add a vertical label with magnitude
             if cloc == (self.nsites - 1):
@@ -1103,13 +1363,56 @@ class MagnitudeDistanceSpectraTrellis(MagnitudeIMTTrellis):
             ax.grid(True)
             self._set_labels(i_m, ax)
 
-
     def _set_labels(self, i_m, ax):
         """
         Sets the labels on the specified axes
         """
         ax.set_xlabel("Period (s)", fontsize=14)
         ax.set_ylabel("Sa (g)", fontsize=14)
+
+    def to_json(self, filename):
+        """
+        Export ground motion values dictionary to json
+        """
+        gmvs = self.get_ground_motion_values()
+        periods = [float(val.split("SA(")[1].rstrip(")"))
+                   for val in self.imts]
+
+        gmv_dict = OrderedDict([
+            ("xlabel", "Period (s)"),
+            ("xvalues", periods),
+            ("ylabel", self._get_ylabel(None)),
+            ("figures", OrderedDict([]))
+            ])
+
+        mags = [rup.mag for rup in self.magnitudes]
+        dists = self.distances[0][self.distance_type]
+        for i, mag in enumerate(mags):
+            for j, dist in enumerate(dists):
+                pos_name = "{:g}-{:g}".format(i, j) 
+                gmv_dict["figures"][pos_name] = OrderedDict([
+                    ("magnitude", mag),
+                    ("distance", np.around(dist, 3)),
+                    ("row", i),
+                    ("column", j),
+                    ("yvalues", OrderedDict([(gsim, []) for gsim in gmvs]))
+                ])
+                for gsim in gmvs:
+                    for imt in self.imts:
+                        if len(gmvs[gsim][imt]):
+                            gmv_dict["figures"][pos_name]["yvalues"][gsim].\
+                                append(gmvs[gsim][imt][i, j])
+                        else:
+                            gmv_dict["figures"][pos_name]["yvalues"][gsim].\
+                                append(None)
+        json.dump(gmv_dict, open(filename, "w"))
+
+    def _get_ylabel(self, i_m):
+        """
+        In this case only the spectra are being shown, so return only the
+        Sa (g) label
+        """
+        return "Sa (g)"
 
     def pretty_print(self, filename=None, sep=","):
         """
@@ -1125,10 +1428,7 @@ class MagnitudeDistanceSpectraTrellis(MagnitudeIMTTrellis):
             fid = sys.stdout
         # Print Meta information
         self._write_pprint_header_line(fid, sep)
-         # Loop over IMTs
-        #if self.rupture:
-        #    gmvs = self.get_ground_motion_values_from_rupture()
-        #else:
+        # Loop over IMTs
         gmvs = self.get_ground_motion_values()
         # Get the GMPE list header string
         gsim_str = "IMT{:s}{:s}".format(
@@ -1160,7 +1460,7 @@ class MagnitudeDistanceSpectraTrellis(MagnitudeIMTTrellis):
                     imt_str = imt.split("(")[1].rstrip(")")
                     iml_str = sep.join(iml_str)
                     fid.write("{:s}{:s}{:s}\n".format(imt_str, sep, iml_str))
-                fid.write("====================================================\n")
+                fid.write("================================================\n")
         if filename:
             fid.close()
 
@@ -1210,36 +1510,34 @@ class MagnitudeDistanceSpectraSigmaTrellis(MagnitudeDistanceSpectraTrellis):
             min_period = np.min(periods) if np.min(periods) < min_period else \
                 min_period
 
-            #spec = np.array([gmvs[gmpe.__class__.__name__][i_m][rloc, cloc]
-            #                 for i_m in self.imts])
             if self.plot_type == "loglog":
                 line, = ax.semilogx(periods,
                                   spec,
-                                  #"-",
                                   linewidth=2.0,
                                   label=gmpe_name)
             else:
                 line, = ax.plot(periods,
                                     spec,
-                                    #"-",
                                     linewidth=2.0,
                                     label=gmpe_name)
             # On the top row, add the distance as a title
             if rloc == 0:
                 ax.set_title("%s = %9.3f (km)" %(
                     self.distance_type,
-                    self.distances[self.distance_type][cloc]),
-                    fontsize=12)
+                    self.distances[0][self.distance_type][cloc]),
+                    fontsize=14)
             # On the last column add a vertical label with magnitude
             if cloc == (self.nsites - 1):
                 ax.annotate("M = %s" % self.rctx[rloc].mag,
-                            (1.02, 0.5),
+                            (1.05, 0.5),
                             xycoords="axes fraction",
-                            fontsize=12,
+                            fontsize=14,
                             rotation="vertical")
 
             self.lines.append(line)
             ax.set_xlim(min_period, max_period)
+            if isinstance(self.ylim, tuple):
+                ax.set_ylim(self.ylim[0], self.ylim[1])
             ax.grid(True)
             self._set_labels(i_m, ax)
 
@@ -1256,15 +1554,12 @@ class MagnitudeDistanceSpectraSigmaTrellis(MagnitudeDistanceSpectraTrellis):
             gmpe_name = _get_gmpe_name(gmpe)
             gmvs.update([(gmpe_name, {})])
             for i_m in self.imts:
-                gmvs[gmpe_name][i_m] = np.zeros([len(self.rctx),
-                                                               self.nsites],
-                                                               dtype=float)
-                for iloc, rct in enumerate(self.rctx):
+                gmvs[gmpe_name][i_m] = np.zeros([len(self.rctx), self.nsites],
+                                                dtype=float)
+                for iloc, (rct, dct) in enumerate(zip(self.rctx, self.dctx)):
                     try:
                         _, sigmas = gmpe.get_mean_and_stddevs(
-                             self.sctx,
-                             rct,
-                             self.dctx,
+                             self.sctx, rct,dct,
                              imt.from_string(i_m),
                              [self.stddevs])
                         gmvs[gmpe_name][i_m][iloc, :] = sigmas[0]
@@ -1272,14 +1567,20 @@ class MagnitudeDistanceSpectraSigmaTrellis(MagnitudeDistanceSpectraTrellis):
                         gmvs[gmpe_name][i_m] = []
                         break
         return gmvs
-    
-    
+
     def _set_labels(self, i_m, ax):
         """
         Sets the labels on the specified axes
         """
         ax.set_xlabel("Period (s)", fontsize=14)
         ax.set_ylabel("%s Std. Dev." % self.stddevs, fontsize=14)
+
+    def _get_ylabel(self, i_m):
+        """
+        Returns the standard deviation term (specific to the standard deviation
+        type specified for the class)
+        """
+        return "{:s} Std. Dev.".format(self.stddevs)
 
     def _write_pprint_header_line(self, fid, sep=","):
         """
@@ -1290,3 +1591,180 @@ class MagnitudeDistanceSpectraSigmaTrellis(MagnitudeDistanceSpectraTrellis):
         fid.write("%s\n" % sep.join(["{:s}{:s}{:s}".format(key, sep, str(val))
                                      for (key, val) in self.params.items()]))
 
+
+#class MagnitudeDistanceSpectraTrellis(MagnitudeIMTTrellis):
+#    """
+#
+#    """
+#    def __init__(self, magnitudes, distances, gsims, imts, params,
+#            stddevs="Total", **kwargs):
+#        """ 
+#        """
+#        imts = ["SA(%s)" % i_m for i_m in imts]
+#
+#        super(MagnitudeDistanceSpectraTrellis, self).__init__(magnitudes, 
+#            distances, gsims, imts, params, stddevs, **kwargs)
+#    
+#
+#    def create_plot(self):
+#        """
+#        Create plot!
+#        """
+#        nrow = len(self.magnitudes)
+#        # Get means and standard deviations
+#        gmvs = self.get_ground_motion_values()
+#        fig = plt.figure(figsize=self.figure_size)
+#        fig.set_tight_layout({"pad":0.5})
+#        for rowloc in xrange(nrow):
+#            for colloc in xrange(self.nsites):
+#                self._build_plot(
+#                    plt.subplot2grid((nrow, self.nsites), (rowloc, colloc)), 
+#                    gmvs,
+#                    rowloc,
+#                    colloc)
+#        # Add legend
+#        lgd = plt.legend(self.lines,
+#                         self.labels,
+#                         loc=2,
+#                         bbox_to_anchor=(1.1, 1.),
+#                         ncol=self.ncol)
+#        _save_image_tight(fig, lgd, self.filename, self.filetype, self.dpi)
+#        plt.show()
+#
+#
+#
+#    def _build_plot(self, ax, gmvs, rloc, cloc):
+#        """
+#        Plots the lines for a given axis
+#        :param ax:
+#            Axes object
+#        :param str i_m:
+#            Intensity Measure
+#        :param dict gmvs:
+#            Ground Motion Values Dictionary
+#        """
+#        self.labels = []
+#        self.lines = []
+#        #periods = np.array([imt.from_string(i_m).period
+#        #                    for i_m in self.imts])
+#        max_period = 0.0
+#        min_period = np.inf
+#        for gmpe in self.gsims:
+#            periods = []
+#            spec = []
+#            gmpe_name = _get_gmpe_name(gmpe)
+#            for i_m in self.imts:
+#                if len(gmvs[gmpe_name][i_m]):
+#                    periods.append(imt.from_string(i_m).period)
+#                    spec.append(gmvs[gmpe_name][i_m][rloc, cloc])
+#            periods = np.array(periods)
+#            spec = np.array(spec)
+#            max_period = np.max(periods) if np.max(periods) > max_period else \
+#                max_period
+#            min_period = np.min(periods) if np.min(periods) < min_period else \
+#                min_period
+#
+#                    
+#            self.labels.append(gmpe_name)
+#            # Get spectrum from gmvs
+#            if self.plot_type == "loglog":
+#                line, = ax.loglog(periods,
+#                                  spec,
+#                                  #"-",
+#                                  linewidth=2.0,
+#                                  label=gmpe_name)
+#            else:
+#                line, = ax.semilogy(periods,
+#                                    spec,
+#                                    #"-",
+#                                    linewidth=2.0,
+#                                    label=gmpe_name)
+#            # On the top row, add the distance as a title
+#            if rloc == 0:
+#                ax.set_title("%s = %9.3f (km)" %(
+#                    self.distance_type,
+#                    self.distances[self.distance_type][cloc]),
+#                    fontsize=14)
+#            # On the last column add a vertical label with magnitude
+#            if cloc == (self.nsites - 1):
+#                ax.annotate("M = %s" % self.rctx[rloc].mag,
+#                            (1.05, 0.5),
+#                            xycoords="axes fraction",
+#                            fontsize=14,
+#                            rotation="vertical")
+#
+#            self.lines.append(line)
+#            ax.set_xlim(min_period, max_period)
+#            if isinstance(self.ylim, tuple):
+#                ax.set_ylim(self.ylim[0], self.ylim[1])
+#            ax.grid(True)
+#            self._set_labels(i_m, ax)
+#
+#
+#    def _set_labels(self, i_m, ax):
+#        """
+#        Sets the labels on the specified axes
+#        """
+#        ax.set_xlabel("Period (s)", fontsize=14)
+#        ax.set_ylabel("Sa (g)", fontsize=14)
+#
+#    def pretty_print(self, filename=None, sep=","):
+#        """
+#        Format the ground motion for printing to file or to screen
+#        :param str filename:
+#            Path to file
+#        :param str sep:
+#            Separator character
+#        """
+#        if filename:
+#            fid = open(filename, "w")
+#        else:
+#            fid = sys.stdout
+#        # Print Meta information
+#        self._write_pprint_header_line(fid, sep)
+#         # Loop over IMTs
+#        #if self.rupture:
+#        #    gmvs = self.get_ground_motion_values_from_rupture()
+#        #else:
+#        gmvs = self.get_ground_motion_values()
+#        # Get the GMPE list header string
+#        gsim_str = "IMT{:s}{:s}".format(
+#            sep,
+#            sep.join([_get_gmpe_name(gsim) for gsim in self.gsims]))
+#        for i, mag in enumerate(self.magnitudes):
+#            for j in range(self.nsites):
+#                dist_string = sep.join([
+#                    "{:s}{:s}{:s}".format(dist_type, sep, str(val[j]))
+#                    for (dist_type, val) in self.distances.items()])
+#                # Get M-R header string
+#                mr_header = "Magnitude{:s}{:s}{:s}{:s}".format(sep, str(mag),
+#                                                               sep,
+#                                                               dist_string)
+#                fid.write("%s\n" % mr_header)
+#                fid.write("%s\n" % gsim_str)
+#                for imt in self.imts:
+#                    iml_str = []
+#                    for gsim in self.gsims:
+#                        gmpe_name = _get_gmpe_name(gsim)
+#                        # Need to deal with case that GSIMs don't define
+#                        # values for the period
+#                        if len(gmvs[gmpe_name][imt]):
+#                            iml_str.append("{:.8f}".format(
+#                                gmvs[gmpe_name][imt][i, j]))
+#                        else:
+#                            iml_str.append("-999.000")
+#                    # Retreived IMT string
+#                    imt_str = imt.split("(")[1].rstrip(")")
+#                    iml_str = sep.join(iml_str)
+#                    fid.write("{:s}{:s}{:s}\n".format(imt_str, sep, iml_str))
+#                fid.write("====================================================\n")
+#        if filename:
+#            fid.close()
+#
+#    def _write_pprint_header_line(self, fid, sep=","):
+#        """
+#        Write the header lines of the pretty print function
+#        """
+#        fid.write("Magnitude - Distance Spectra (km) IMT Trellis\n")
+#        fid.write("%s\n" % sep.join(["{:s}{:s}{:s}".format(key, sep, str(val))
+#                                     for (key, val) in self.params.items()]))


### PR DESCRIPTION
Refactor of the Trellis Plotting to resolve the following issues:

1. Magnitude Trellis and Magnitude-Distance Spectra trellis were lacking methods to instantiate from a rupture model. This is because when the rupture size changes (with magnitude) it would be necessary to rebuild the rupture for each magnitude. This capability has now been added such that the user need only input a single dictionary with the configuration settings of the rupture object in order to get the functionality to work.

2. The ground motion values of the trellis plots can now be exported to json, for easy and organised parsing.
