### PR TITLE
Adds IMS and response spectra tests

### DIFF
--- a/smtk/intensity_measures.py
+++ b/smtk/intensity_measures.py
@@ -186,7 +186,7 @@ def get_response_spectrum(acceleration, time_step, periods, damping=0.05,
                                         periods, 
                                         damping,
                                         units)
-    spectrum, time_series, accel, vel, disp = response_spec.evaluate()
+    spectrum, time_series, accel, vel, disp = response_spec()
     spectrum["PGA"] = time_series["PGA"]
     spectrum["PGV"] = time_series["PGV"]
     spectrum["PGD"] = time_series["PGD"]
@@ -231,7 +231,7 @@ def geometric_mean_spectrum(sax, say):
         Dictionary of response spectrum outputs from y-component
     """
     sa_gm = {}
-    for key in sax.keys():
+    for key in sax:
         if key == "Period":
             sa_gm[key] = sax[key]
         else:
@@ -243,7 +243,7 @@ def arithmetic_mean_spectrum(sax, say):
     Returns the arithmetic mean of the response spectrum
     """
     sa_am = {}
-    for key in sax.keys():
+    for key in sax:
         if key == "Period":
             sa_am[key] = sax[key]
         else:
@@ -255,7 +255,7 @@ def envelope_spectrum(sax, say):
     Returns the envelope of the response spectrum
     """
     sa_env = {}
-    for key in sax.keys():
+    for key in sax:
         if key == "Period":
             sa_env[key] = sax[key]
         else:

--- a/smtk/response_spectrum.py
+++ b/smtk/response_spectrum.py
@@ -26,7 +26,7 @@ import numpy as np
 from math import sqrt
 from scipy.integrate import cumtrapz
 import matplotlib.pyplot as plt
-from sm_utils import (_save_image,
+from smtk.sm_utils import (_save_image,
                       get_time_vector,
                       convert_accel_units,
                       get_velocity_displacement)
@@ -62,7 +62,7 @@ class ResponseSpectrum(object):
         self.response_spectrum = None
 
 
-    def evaluate(self):
+    def __call__(self):
         '''
         Evaluates the response spectrum
         :returns:
@@ -88,9 +88,8 @@ class ResponseSpectrum(object):
             accel - Acceleration response of Single Degree of Freedom Oscillator 
             vel - Velocity response of Single Degree of Freedom Oscillator 
             disp - Displacement response of Single Degree of Freedom Oscillator 
-
         '''
-
+        raise NotImplementedError("Cannot call Base Response Spectrum")
 
 
 class NewmarkBeta(ResponseSpectrum):
@@ -98,7 +97,7 @@ class NewmarkBeta(ResponseSpectrum):
     Evaluates the response spectrum using the Newmark-Beta methodology
     '''
 
-    def evaluate(self):
+    def __call__(self):
         '''
         Evaluates the response spectrum
         :returns:
@@ -188,6 +187,7 @@ class NewmarkBeta(ResponseSpectrum):
             a_t[j, :] = self.acceleration[j] + accel[j, :]
         return accel, vel, disp, a_t
 
+
 class NigamJennings(ResponseSpectrum):
     """
     Evaluate the response spectrum using the algorithm of Nigam & Jennings
@@ -197,7 +197,7 @@ class NigamJennings(ResponseSpectrum):
     of the sampling frequency.
     """
 
-    def evaluate(self):
+    def __call__(self):
         """
         Define the response spectrum
         """

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -233,7 +233,7 @@ class FocalMechanism(object):
         Returns an idealised "rake" based on a qualitative description of the
         style of faulting
         """
-        if self.mechanism_type in MECHANISM_TYPE.keys():
+        if self.mechanism_type in MECHANISM_TYPE:
             return MECHANISM_TYPE[self.mechanism_type]
         else:
             return 0.0
@@ -486,7 +486,7 @@ class RecordSite(object):
         if self.ec8:
             return self.ec8
         if self.vs30:
-            for key in EC8_VS30_BOUNDARIES.keys():
+            for key in EC8_VS30_BOUNDARIES:
                 in_group = (self.vs30 >= EC8_VS30_BOUNDARIES[key][0]) and\
                     (self.vs30 < EC8_VS30_BOUNDARIES[key][1])
                 if in_group:
@@ -494,14 +494,14 @@ class RecordSite(object):
                     return self.ec8
         elif self.nspt:
             # Check to see if a site class can be determined from NSPT
-            for key in EC8_NSPT_BOUNDARIES.keys():
+            for key in EC8_NSPT_BOUNDARIES:
                 in_group = (self.nspt >= EC8_NSPT_BOUNDARIES[key][0]) and\
                     (self.nspt < EC8_NSPT_BOUNDARIES[key][1])
                 if in_group:
                     self.ec8 = key
                     return self.ec8
         else:
-            print "Cannot determine EC8 site class - no Vs30 or NSPT measures!"
+            print("Cannot determine EC8 site class - no Vs30 or NSPT measures!")
         return None
     
     def get_nehrp_class(self):
@@ -511,7 +511,7 @@ class RecordSite(object):
         if self.nehrp:
             return self.nehrp
         if self.vs30:
-            for key in NEHRP_VS30_BOUNDARIES.keys():
+            for key in NEHRP_VS30_BOUNDARIES:
                 in_group = (self.vs30 >= NEHRP_VS30_BOUNDARIES[key][0]) and\
                     (self.vs30 < NEHRP_VS30_BOUNDARIES[key][1])
                 if in_group:
@@ -519,14 +519,14 @@ class RecordSite(object):
                     return self.nehrp
         elif self.nspt:
             # Check to see if a site class can be determined from NSPT
-            for key in NEHRP_NSPT_BOUNDARIES.keys():
+            for key in NEHRP_NSPT_BOUNDARIES:
                 in_group = (self.nspt >= NEHRP_NSPT_BOUNDARIES[key][0]) and\
                     (self.nspt < NEHRP_NSPT_BOUNDARIES[key][1])
                 if in_group:
                     self.nehrp = key
                     return self.nehrp
         else:
-            print "Cannot determine NEHRP site class - no Vs30 or NSPT measures!"
+            print("Cannot determine NEHRP site class - no Vs30 or NSPT measures!")
         return None
 
 
@@ -546,7 +546,7 @@ class RecordSite(object):
         if self.ec8 == 'E':
             return 100
         else:
-            print "Cannot determine Vs30 from EC8 site class"
+            print("Cannot determine Vs30 from EC8 site class")
 
 Filter = {'Type': None,
           'Order': None,

--- a/smtk/strong_motion_selector.py
+++ b/smtk/strong_motion_selector.py
@@ -37,14 +37,14 @@ def rank_sites_by_record_count(database, threshold=0):
     name_id_list = [(rec.site.id, rec.site.name) for rec in database.records]
     name_id = dict([])
     for name_id_pair in name_id_list:
-        if name_id_pair[0] in name_id.keys():
+        if name_id_pair[0] in name_id:
             name_id[name_id_pair[0]]["Count"] += 1
         else:
             name_id[name_id_pair[0]] = {"Count": 1, "Name": name_id_pair[1]}
-    counts = np.array([name_id[key]["Count"] for key in name_id.keys()])
+    counts = np.array([name_id[key]["Count"] for key in name_id])
     sort_id = np.flipud(np.argsort(counts))
 
-    key_vals = name_id.keys()
+    key_vals = list(name_id)
     output_list = []
     for idx in sort_id:
         if name_id[key_vals[idx]]["Count"] >= threshold:
@@ -102,7 +102,8 @@ class SMRecordSelector(object):
         if record_id in self.record_ids:
             return self.database.records[self.record_ids.index(record_id)]
         else:
-            raise ValueError("Record %s is not in database" % record_id)
+            raise ValueError(
+                "Record {:s} is not in database".format(record_id))
 
     def select_from_record_ids(self, record_ids, as_db=False):
         """
@@ -111,7 +112,7 @@ class SMRecordSelector(object):
         idx = []
         for record_id in record_ids:
             if not record_id in self.record_ids:
-                print("Record %s is not in database" % record_id)
+                print("Record {:s} is not in database".format(record_id))
         for iloc, record in enumerate(self.database.records):
             if record.id in record_ids:
                 idx.append(iloc)
@@ -133,7 +134,7 @@ class SMRecordSelector(object):
         """
         for site_id in site_ids:
             if not site_id in self.site_ids:
-                print("Site %s is not in database" % record_id)
+                print("Site {:w is not in database" % record_id)
         idx = []
         for iloc, record in enumerate(self.database.records):
             if record.site.id in site_ids:
@@ -158,7 +159,7 @@ class SMRecordSelector(object):
         """
         for event_id in event_ids:
             if not event_id in self.event_ids:
-                print("Event %s not found in database" % event_id)
+                print("Event {:s} not found in database".format(event_id))
         idx = []
         for iloc, record in enumerate(self.database.records):
             if record.event.id in event_ids:
@@ -345,8 +346,8 @@ class SMRecordSelector(object):
 #                    raise ValueError("Record %s is missing selected distance "
 #                        "metric and alternative metric" % record.id)
             else:
-                print("Record %s is missing selected distance metric"
-                      % record.id)
+                print("Record {:s} is missing selected distance metric".format(
+                      record.id))
         return self.select_records(idx, as_db)
 
     # Event-based selection

--- a/tests/intensity_measures_test.py
+++ b/tests/intensity_measures_test.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2014-2017 GEM Foundation and G. Weatherill
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+"""
+Tests for generation of data for trellis plots
+"""
+import unittest
+import os
+import h5py
+import numpy as np
+import smtk.response_spectrum as rsp
+import smtk.intensity_measures as ims
+
+
+BASE_DATA_PATH = os.path.dirname(__file__)
+
+
+class BaseIMSTestCase(unittest.TestCase):
+    """
+    Base test case for Response Spectra and Intensity Measure functions
+    """
+
+    @staticmethod
+    def arr_diff(x, y, percent):
+        """
+        Retrieving data from hdf5 leads to precision differences use relative
+        error (i.e. < X % difference)
+        """
+        idx = np.logical_and(x > 0.0, y > 0.0)
+        diff = np.zeros_like(x)
+        diff[idx] = ((x[idx] / y[idx]) - 1.0) * 100
+        if np.all(np.fabs(diff) < percent):
+            return True
+        else:
+            iloc = np.argmax(diff)
+            print(x, y, diff, x[iloc], y[iloc], diff[iloc])
+            return False
+        
+    def _compare_sa_sets(self, sax, fle_loc, disc=1.0):
+        """
+        When data is stored in a dictionary of arrays, compare by keys
+        """
+        for key in sax:
+            if not isinstance(sax[key], np.ndarray) or len(sax[key]) == 1:
+                continue
+            reference_data = self.fle[fle_loc + "/{:s}".format(key)][:]
+            self.assertTrue(self.arr_diff(sax[key], reference_data, disc))
+
+    def setUp(self):
+        """
+        Connect to hdf5 data store
+        """
+        self.fle = h5py.File(os.path.join(BASE_DATA_PATH,
+                                          "smtk_ims_test_data.hdf5"), "r")
+        self.periods = self.fle["INPUTS/periods"][:]
+
+    def tearDown(self):
+        """
+        Close hdf5 connection
+        """
+        self.fle.close()
+
+
+class ResponseSpectrumTestCase(BaseIMSTestCase):
+    """
+    Tests the response spectrum methods
+    """
+
+    def test_response_spectrum(self):
+        """
+        Tests the Nigam & Jennings Response Spectrum
+        """
+        x_record = self.fle["INPUTS/RECORD1/XRECORD"][:]
+        x_time_step = self.fle["INPUTS/RECORD1/XRECORD"].attrs["timestep"]
+        nigam_jennings = rsp.NigamJennings(x_record, x_time_step, self.periods,
+                                           damping=0.05, units="cm/s/s")
+        sax, timeseries, acc, vel, dis = nigam_jennings()
+        self._compare_sa_sets(sax, "TEST1/X/spectra")
+        for key in ["Acceleration", "Velocity", "Displacement"]:
+            if not isinstance(timeseries[key], np.ndarray):
+                continue
+            self.assertTrue(
+                self.arr_diff(timeseries[key],
+                              self.fle["TEST1/X/timeseries/{:s}".format(key)][:],
+                              1.0)
+                )
+
+    def test_get_response_spectrum_pair(self):
+        """
+        Tests the call to the response spectrum via ims
+        """
+        sax, say = ims.get_response_spectrum_pair(
+            self.fle["INPUTS/RECORD1/XRECORD"][:],
+            self.fle["INPUTS/RECORD1/XRECORD"].attrs["timestep"],
+            self.fle["INPUTS/RECORD1/YRECORD"][:],
+            self.fle["INPUTS/RECORD1/YRECORD"].attrs["timestep"],
+            self.periods, damping=0.05, units="cm/s/s",
+            method="Nigam-Jennings")
+        self._compare_sa_sets(sax, "TEST1/X/spectra")
+        self._compare_sa_sets(say, "TEST1/Y/spectra")
+
+    def test_get_geometric_mean_spectrum(self):
+        """
+        Tests the geometric mean spectrum
+        """
+        sax, say = ims.get_response_spectrum_pair(
+            self.fle["INPUTS/RECORD1/XRECORD"][:],
+            self.fle["INPUTS/RECORD1/XRECORD"].attrs["timestep"],
+            self.fle["INPUTS/RECORD1/YRECORD"][:],
+            self.fle["INPUTS/RECORD1/YRECORD"].attrs["timestep"],
+            self.periods, damping=0.05, units="cm/s/s",
+            method="Nigam-Jennings")
+        sa_gm = ims.geometric_mean_spectrum(sax, say)
+        self._compare_sa_sets(sa_gm, "TEST1/GM/spectra")
+    
+    def test_envelope_spectrum(self):
+        """
+        Tests the envelope spectrum
+        """
+        sax, say = ims.get_response_spectrum_pair(
+            self.fle["INPUTS/RECORD1/XRECORD"][:],
+            self.fle["INPUTS/RECORD1/XRECORD"].attrs["timestep"],
+            self.fle["INPUTS/RECORD1/YRECORD"][:],
+            self.fle["INPUTS/RECORD1/YRECORD"].attrs["timestep"],
+            self.periods, damping=0.05, units="cm/s/s",
+            method="Nigam-Jennings")
+        sa_env = ims.envelope_spectrum(sax, say)
+        self._compare_sa_sets(sa_env, "TEST1/ENV/spectra")
+ 
+    def test_gmrotd50(self):
+        """
+        Tests the function to get GMRotD50
+        """
+        gmrotd50 = ims.gmrotdpp(
+            self.fle["INPUTS/RECORD1/XRECORD"][:],
+            self.fle["INPUTS/RECORD1/XRECORD"].attrs["timestep"],
+            self.fle["INPUTS/RECORD1/YRECORD"][:],
+            self.fle["INPUTS/RECORD1/YRECORD"].attrs["timestep"],
+            self.periods, percentile=50.0, damping=0.05, units="cm/s/s",
+            method="Nigam-Jennings")
+        self._compare_sa_sets(gmrotd50, "TEST1/GMRotD50/spectra")
+
+    def test_gmroti50(self):
+        """
+        Tests the function to get GMRotI50
+        """
+        gmroti50 = ims.gmrotipp(
+            self.fle["INPUTS/RECORD1/XRECORD"][:],
+            self.fle["INPUTS/RECORD1/XRECORD"].attrs["timestep"],
+            self.fle["INPUTS/RECORD1/YRECORD"][:],
+            self.fle["INPUTS/RECORD1/YRECORD"].attrs["timestep"],
+            self.periods, percentile=50.0, damping=0.05, units="cm/s/s",
+            method="Nigam-Jennings")
+        self._compare_sa_sets(gmroti50, "TEST1/GMRotI50/spectra")
+
+
+class ScalarIntensityMeasureTestCase(BaseIMSTestCase):
+    """
+    Tests the functions returning scalar intensity measures
+    """
+    def test_get_peak_measures(self):
+        """
+        Tests the PGA, PGV, PGD functions
+        """
+        pga_x, pgv_x, pgd_x, _, _ = ims.get_peak_measures(
+            self.fle["INPUTS/RECORD1/XRECORD"].attrs["timestep"],
+            self.fle["INPUTS/RECORD1/XRECORD"][:],
+            True,
+            True)
+        self.assertAlmostEqual(pga_x, 523.6900024, 3)
+        self.assertAlmostEqual(pgv_x, 46.7632261, 3)
+        self.assertAlmostEqual(pgd_x, 13.6729804, 3)
+
+    def test_get_durations(self):
+        """
+        Tests the bracketed, uniform and significant duration
+        """
+        x_record = self.fle["INPUTS/RECORD1/XRECORD"][:]
+        x_timestep = self.fle["INPUTS/RECORD1/XRECORD"].attrs["timestep"]
+        self.assertAlmostEqual(
+            ims.get_bracketed_duration(x_record, x_timestep, 5.0),
+            19.7360000, 3)
+        
+        self.assertAlmostEqual(
+            ims.get_uniform_duration(x_record, x_timestep, 5.0),
+            14.6820000, 3)
+                               
+        self.assertAlmostEqual(
+            ims.get_significant_duration(x_record, x_timestep, 0.05, 0.95),
+            4.0320000, 3)
+
+    def test_arias_cav_arms(self):
+        """
+        Tests the functions for Ia, CAV, CAV5 and Arms
+        """
+        x_record = self.fle["INPUTS/RECORD1/XRECORD"][:]
+        x_timestep = self.fle["INPUTS/RECORD1/XRECORD"].attrs["timestep"]
+        # Arias intensity
+        self.assertAlmostEqual(
+            ims.get_arias_intensity(x_record, x_timestep),
+            111.1540091, 3)
+        # 5 - 95 % Arias Intensity
+        self.assertAlmostEqual(
+            ims.get_arias_intensity(x_record, x_timestep, 0.05, 0.95),
+            99.9621952, 3)
+        # CAV
+        self.assertAlmostEqual(
+            ims.get_cav(x_record, x_timestep),
+            509.9941624, 3)
+        # CAV5
+        self.assertAlmostEqual(
+            ims.get_cav(x_record, x_timestep, threshold=5.0),
+            496.7741956, 3)
+        # Arms
+        self.assertAlmostEqual(
+            ims.get_arms(x_record, x_timestep),
+            56.8495087, 3)
+
+    def test_spectrum_intensities(self):
+        """
+        Tests Housner Intensity and Acceleration Spectrum Intensity
+        """
+        x_record = self.fle["INPUTS/RECORD1/XRECORD"][:]
+        x_timestep = self.fle["INPUTS/RECORD1/XRECORD"].attrs["timestep"]
+        sax = ims.get_response_spectrum(x_record, x_timestep, self.periods)[0]
+        housner = ims.get_response_spectrum_intensity(sax)
+        self.assertAlmostEqual(housner, 121.3103787, 3)
+        asi = ims.get_acceleration_spectrum_intensity(sax)
+        self.assertAlmostEqual(asi, 432.5134666, 3)


### PR DESCRIPTION
1. Adds preliminary test suite for intensity measures and response spectra (more to follow).
2. More changes for Python 2 & 3 compatibility (Addresses: https://github.com/GEMScienceTools/gmpe-smtk/issues/59)
3. Change `ResponseSpectrum` to replace `evaluate` method with `__call__`. Closes https://github.com/GEMScienceTools/gmpe-smtk/issues/59

From this point onward response spectra should be called with 
```python
nigam_jennings = rsp.NigamJennings(x_record, x_time_step, periods, damping=0.05, units="cm/s/s")
sax, time_series, acc, vel, dis = nigam_jennings()
```
or

```python
sax, time_series, acc, vel, dis = rsp.NigamJennings(x_record, x_time_step, periods, damping=0.05, units="cm/s/s")()
```