### PR TITLE
Removes Python 3.5, 3.6 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: python
 
 python:
  - "2.7"
- - "3.5"
- - "3.6"
+# - "3.5"
+# - "3.6"
 
 addons:
   apt:


### PR DESCRIPTION
Whilst Python 3.5/3.6 migration is underway, this temporarily removes Python 3 from travis CI