### PR TITLE
Renamed gsim_table -> gmpe_table

### DIFF
--- a/smtk/residuals/gmpe_residuals.py
+++ b/smtk/residuals/gmpe_residuals.py
@@ -38,7 +38,7 @@ from copy import deepcopy
 from collections import OrderedDict
 from openquake.baselib import parallel
 from openquake.hazardlib.gsim import get_available_gsims
-from openquake.hazardlib.gsim.gsim_table import GMPETable
+from openquake.hazardlib.gsim.gmpe_table import GMPETable
 import smtk.intensity_measures as ims
 from openquake.hazardlib import imt
 from smtk.strong_motion_selector import SMRecordSelector

--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -35,7 +35,7 @@ from openquake.hazardlib import gsim, imt
 from openquake.hazardlib.gsim.base import (RuptureContext,
                                            DistancesContext,
                                            SitesContext)
-from openquake.hazardlib.gsim.gsim_table import GMPETable
+from openquake.hazardlib.gsim.gmpe_table import GMPETable
 from openquake.hazardlib.scalerel.wc1994 import WC1994
 from smtk.sm_utils import _save_image, _save_image_tight
 import smtk.trellis.trellis_utils as utils


### PR DESCRIPTION
This fixes an error caused by a module rename in hazardlib.