### PR TITLE
Adds support for storing metadata as json

### DIFF
--- a/smtk/__init__.py
+++ b/smtk/__init__.py
@@ -15,3 +15,39 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+import os
+import sys
+import json
+from smtk.sm_database import GroundMotionDatabase
+
+if sys.version_info[0] >= 3:
+    import pickle
+else:
+    import cPickle as pickle
+
+def load_database(directory):
+    """
+    Wrapper function to load the metadata of a strong motion database
+    according to the filetype
+    """
+    metadata_file = None
+    filetype = None
+    fileset = os.listdir(directory)
+    for ftype in ["pkl", "json"]:
+        if ("metadatafile.%s" % ftype) in fileset:
+            metadata_file = "metadatafile.%s" % ftype
+            filetype = ftype
+            break
+    if not metadata_file:
+        raise IOError("Expected metadata file of supported type not found in %s"
+                      % directory)
+    metadata_path = os.path.join(directory, metadata_file)
+    if filetype == "json":
+        # json metadata filetype
+        return GroundMotionDatabase.from_json(metadata_path)
+    elif filetype == "pkl":
+        # pkl file type
+        with open(metadata_path, "rb") as f:
+            return pickle.load(f)
+    else:
+        raise ValueError("Metadata filetype %s not supported" % ftype)

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -24,7 +24,9 @@ motion records
 import os
 import h5py
 import numpy as np
+import json
 from datetime import datetime
+from collections import OrderedDict, namedtuple
 from openquake.hazardlib.gsim.base import (SitesContext, DistancesContext,
                                           RuptureContext)
 from openquake.hazardlib.site import Site, SiteCollection
@@ -32,6 +34,7 @@ from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.scalerel import PeerMSR
 from smtk.trellis.configure import vs30_to_z1pt0_as08, z1pt0_to_z2pt5
 from smtk.trellis.configure import vs30_to_z1pt0_cy14, vs30_to_z2pt5_cb14
+import smtk.sm_utils as utils
 
 DEFAULT_MSR = PeerMSR()
 
@@ -53,6 +56,28 @@ class Magnitude(object):
         self.mtype = mtype
         self.sigma = sigma
         self.source = source
+
+    @classmethod
+    def from_dict(cls, d):
+        """
+        Instantiates the object from a dictionary
+        """
+        return cls(d["value"], d["mtype"], d["sigma"], d["source"])
+
+    def to_dict(self):
+        return self.__dict__
+
+    def __eq__(self, m):
+        """
+        """
+        same_value = np.fabs(self.value - m.value) < 1.0E-3
+        if self.sigma and m.sigma:
+            same_sigma = np.fabs(self.sigma - m.sigma) < 1.0E-7
+        else:
+            same_sigma = self.sigma == m.sigma
+        return same_value and same_sigma and (self.mtype == m.mtype) and\
+            (self.source == m.source)
+
 
 class Rupture(object):
     """
@@ -96,7 +121,15 @@ class Rupture(object):
         self.hypo_loc = hypo_loc
         self.aspect = None
         self.aspect = self.get_aspect()
-
+        # QuakeML parameters
+        self.max_displacement = None  # in m
+        self.mean_displacement = None  # in m
+        self.moment_release_top_5km = None
+        self.rise_time = None
+        self.velocity = None
+        self.shallow_asperity = False
+        self.stress_drop = None
+        self.vr_to_vs = None
 
     def get_area(self):
         """
@@ -129,7 +162,44 @@ class Rupture(object):
             return self.length / self.width
         # out of options - returning None
         return None
-  
+
+    def to_dict(self):
+        """
+        """
+        output = OrderedDict([])
+        for key in self.__dict__:
+            if key == "magnitude" and self.magnitude is not None:
+                # Parse magnitude object to dictionary
+                output[key] = self.magnitude.__dict__
+            elif key == "hypocentre" and self.hypocentre is not None:
+                output[key] = [self.hypocentre.longitude,
+                               self.hypocentre.latitude,
+                               self.hypocentre.depth]
+            elif key == "surface" and self.surface is not None:
+                output[key] = utils.surface_to_dict[
+                    self.surface.__class__.__name__](self.surface)
+            else:
+                output[key] = getattr(self, key)
+        return output
+
+    @classmethod
+    def from_dict(cls, data, mesh_spacing=1.):
+        """
+        Creates an instance of the class from a json load
+        """
+        rup = cls(data["id"], data["name"],
+                  Magnitude.from_dict(data["magnitude"]),
+                  data["length"], data["width"], data["depth"])
+        for key in data:
+            if key in ["id", "name", "magnitude", "length", "width", "depth"]:
+                continue
+            elif key == "surface" and data["surface"] is not None:
+                rup.surface = utils.surfaces_from_dict(data[key]["type"],
+                                                       mesh_spacing)
+            else:
+                setattr(rup, key, data[key])
+        return rup
+
 
 class GCMTNodalPlanes(object):
     """
@@ -147,6 +217,21 @@ class GCMTNodalPlanes(object):
         """
         self.nodal_plane_1 = None
         self.nodal_plane_2 = None
+
+    def to_dict(self):
+        """
+        Returns a dictionary
+        """
+        return self.__dict__
+
+    @classmethod
+    def from_dict(cls, data):
+        """
+        """
+        nps = cls()
+        for key in data:
+            setattr(nps, key, data[key])
+        return nps
 
 class GCMTPrincipalAxes(object):
     """
@@ -168,6 +253,22 @@ class GCMTPrincipalAxes(object):
         self.b_axis = None
         self.p_axis = None
 
+    def to_dict(self):
+        """
+        Returns a dictionary
+        """
+        return self.__dict__
+
+    @classmethod
+    def from_dict(cls, data):
+        """
+        """
+        pas = cls()
+        for key in data:
+            setattr(pas, key, data[key])
+        return pas
+
+
 MECHANISM_TYPE = {"Normal": -90.0,
                   "Strike-Slip": 0.0,
                   "Reverse": 90.0,
@@ -185,6 +286,7 @@ MECHANISM_TYPE = {"Normal": -90.0,
                   "O": 0.0
                   }
 
+
 DIP_TYPE = {"Normal": 60.0,
             "Strike-Slip": 90.0,
             "Reverse": 35.0,
@@ -201,6 +303,7 @@ DIP_TYPE = {"Normal": 60.0,
             "TS": 45., # Reverse with strike-slip component
             "O": 90.0
             }
+
 
 class FocalMechanism(object):
     """
@@ -240,6 +343,51 @@ class FocalMechanism(object):
             return MECHANISM_TYPE[self.mechanism_type]
         else:
             return 0.0
+
+    def to_dict(self):
+        """
+        """
+        output = OrderedDict([])
+        for key in self.__dict__:
+            if key in ("nodal_planes", "eigenvalues") and getattr(self, key)\
+                is not None:
+                output[key] = getattr(self, key).__dict__
+            elif key == "tensor":
+                output[key] = self._moment_tensor_to_list()
+            else:
+                output[key] = getattr(self, key)
+        return output
+
+    @classmethod
+    def from_dict(cls, data):
+        """
+        """
+        keys = list(data)
+        if "nodal_planes" in keys and data["nodal_planes"]:
+            nps = GCMTNodalPlanes.from_dict(data["nodal_planes"])
+        else:
+            nps = None
+        if "eigenvalues" in keys and data["eigenvalues"]:
+            eigs =  GCMTPrincipalAxes.from_dict(data[key])
+        else:
+            eigs = None
+        if "tensor" in keys and data["tensor"]:
+            tensor = np.array(data["tensor"])
+        else:
+            tensor = None
+
+        foc_mech = cls(data["id"], data["name"], nps, eigs, tensor)
+        if "mechanism_type" in data:
+            setattr(foc_mech, "mechanism_type", data["mechanism_type"])
+        return foc_mech
+
+    def _moment_tensor_to_list(self):
+        """
+        """
+        if self.tensor is None:
+            return None
+        else:
+            return self.tensor.to_list() 
 
 
 class Earthquake(object):
@@ -282,10 +430,58 @@ class Earthquake(object):
         self.latitude = latitude
         self.depth = depth
         self.magnitude = magnitude
-        self.magnitude_list = None
+        self.magnitude_list = []
         self.mechanism = focal_mechanism
         self.rupture = None
         self.tectonic_region = tectonic_region
+
+    def to_dict(self):
+        """
+        Parses the information to a json compatible dictionary
+        """
+        output = OrderedDict([])
+        for key in self.__dict__:
+            if key == "datetime":
+                output[key] = str(self.datetime)
+            elif key == "magnitude":
+                output[key] = self.magnitude.__dict__
+            elif key == "magnitude_list":
+                output[key] = [mag.__dict__ for mag in self.magnitude_list]
+            elif key in ("mechanism", "rupture") and\
+                getattr(self, key) is not None:
+                output[key] = getattr(self, key).to_dict()
+            else:
+                output[key] = getattr(self, key)
+        return output
+
+    @classmethod
+    def from_dict(cls, data):
+        """
+        Loads the class from a json compatible dictionary
+        """
+        reqs = ["id", "name", "datetime", "longitude", "latitude", "depth",
+                "magnitude"]
+        eqk = cls(data["id"], data["name"],
+                  datetime.strptime(data["datetime"], "%Y-%m-%d %H:%M:%S"),
+                  data["longitude"],
+                  data["latitude"],
+                  data["depth"],
+                  Magnitude.from_dict(data["magnitude"]))
+        
+        for key in data:
+            if key in reqs:
+                continue
+            elif key == "magnitude_list" and len(data[key]):
+                setattr(eqk, key, [Magnitude.from_dict(mag)
+                                   for mag in data[key]])
+            elif key == "mechanism" and data[key]:
+                setattr(eqk, key, FocalMechanism.from_dict(data[key]))
+            elif key == "rupture" and data[key]:
+                setattr(eqk, key, Rupture.from_dict(data[key]))
+            else:
+                setattr(eqk, key, data[key])
+        return eqk
+
 
 class RecordDistance(object):
     """
@@ -305,16 +501,17 @@ class RecordDistance(object):
         Along-track distance from site to surface projection of fault plane
     :param float azimuth:
         Source to site azimuth (degrees)
-    :param flag:
-        ?
     :param bool hanging_wall:
         True if site on hanging wall, False otherwise
+    :param bool flag:
+        Distance flagged according to SigmaDatabase definition
     :param float rcdpp:
-        Direct point parameter for directivity effect centered on the site- and earthquake-specific
+        Direct point parameter for directivity effect centered on the site-
+        and earthquake-specific
         average DPP used
     """
     def __init__(self, repi, rhypo, rjb=None, rrup=None, r_x=None, ry0=None,
-                 flag=None, rcdpp=None, rvolc=None):
+                 flag=None, azimuth=None, rcdpp=None, rvolc=None):
         """
         Instantiates class
         """
@@ -325,10 +522,25 @@ class RecordDistance(object):
         self.r_x = r_x
         self.ry0 = ry0
         self.azimuth = None
-        self.flag = flag
         self.hanging_wall = None
+        self.flag = flag
         self.rcdpp = rcdpp
         self.rvolc = rvolc
+        # QuakeML parameters
+        self.pre_event_length = None
+        self.post_event_length = None
+
+    def to_dict(self):
+        return self.__dict__
+
+    @classmethod
+    def from_dict(cls, data):
+        """
+        """
+        d = cls(data["repi"], data["rhypo"])
+        for key in data:
+            setattr(d, key, data[key])
+        return d
 
 # Eurocode 8 Site Class Vs30 boundaries
 EC8_VS30_BOUNDARIES = {
@@ -447,6 +659,20 @@ class RecordSite(object):
         self.backarc = backarc
         self.morphology = None
         self.slope = None
+
+    def to_dict(self):
+        return self.__dict__
+
+    @classmethod
+    def from_dict(cls, data):
+        """
+        """
+        reqs = ["id", "code", "name", "longitude", "latitude", "altitude"]
+        site = cls(*[data[req] for req in reqs])
+        for key in data:
+            if key not in reqs:
+                setattr(site, key, data[key])
+        return site
 
     def to_openquake_site(self, missing_vs30=None):
         """
@@ -603,8 +829,28 @@ class Component(object):
         self.filter = waveform_filter
         self.baseline = baseline
         self.ims = ims
-        self.units = units
+        self.units = units  # Equivalent to gain unit
         self.late_trigger = None
+        # QuakeML compatible parameters (mostly unused)
+        self.start_time = None
+        self.duration = None
+        self.resample_rate_denominator = None
+        self.resample_rate_numerator = None
+        self.owner = None
+        self.creation_info = None
+
+    def to_dict(self):
+        return self.__dict__
+
+    @classmethod
+    def from_dict(cls, data):
+        """
+        """
+        comp = cls(data["id"], data["orientation"])
+        for key in data:
+            if not key in ["id", "orientation"]:
+                setattr(comp, key, data[key])
+        return comp
 
 
 class GroundMotionRecord(object):
@@ -640,7 +886,7 @@ class GroundMotionRecord(object):
         Data file for strong motion record
     """
     def __init__(self, gm_id, time_series_file, event, distance, record_site,
-                 x_comp, y_comp, vertical=None, ims={}, longest_period=None,
+                 x_comp, y_comp, vertical=None, ims=None, longest_period=None,
                  shortest_period=None, spectra_file=None):
         """
         """
@@ -665,6 +911,46 @@ class GroundMotionRecord(object):
         self.directivity = None
         self.datafile = None
         self.misc = None
+
+    def to_dict(self):
+        """
+        """
+        output = OrderedDict([])
+        for key in self.__dict__:
+            if key in ("event", "distance", "site", "xrecord", "yrecord"):
+                output[key] = getattr(self, key).to_dict()
+            elif key == "vertical" and self.vertical:
+                output[key] = self.vertical.to_dict()
+            else:
+                output[key] = getattr(self, key)
+        return output
+
+    @classmethod
+    def from_dict(cls, data):
+        """
+        """
+        reqs = ["id", "time_series_file", "event", "distance", "site",
+               "xrecord", "yrecord", "vertical"]
+        evnt = cls(data["id"],
+                   data["time_series_file"],
+                   Earthquake.from_dict(data["event"]),
+                   RecordDistance.from_dict(data["distance"]),
+                   RecordSite.from_dict(data["site"]),
+                   Component.from_dict(data["xrecord"]),
+                   Component.from_dict(data["yrecord"]))
+
+        if "vertical" in data and data["vertical"]:
+            evnt.vertical = Component.from_dict(data["vertical"])
+
+        for key in data:
+            if key in reqs:
+                continue
+            elif not data[key]:
+                setattr(evnt, key, None)
+            else:
+                setattr(evnt, key, data[key])
+        return evnt
+            
 
     def get_azimuth(self):
         """
@@ -702,8 +988,35 @@ class GroundMotionDatabase(object):
         self.id = db_id
         self.name = db_name
         self.directory = db_directory
-        self.records = records
+        #self.records = []
+        #print(records)
+        self.records = [rec for rec in records]
         self.site_ids = site_ids
+
+    def to_json(self):
+        """
+        Exports the database to json
+        """
+        json_dict = {"id": self.id,
+                     "name": self.name,
+                     "directory": self.directory,
+                     "records": []}
+        for rec in self.records:
+            json_dict["records"].append(rec.to_dict())
+        return json.dumps(json_dict)
+
+    @classmethod
+    def from_json(cls, filename):
+        """
+        """
+        with open(filename, "r") as f:
+            raw = json.load(f)
+        gmdb = cls(raw["id"], raw["name"], raw["directory"])
+        for record in raw["records"]:
+            gmdb.records.append(GroundMotionRecord.from_dict(record))
+        gmdb.site_ids = [rec.site.id for rec in gmdb.records]
+        return gmdb
+        
 
     def number_records(self):
         """

--- a/smtk/sm_utils.py
+++ b/smtk/sm_utils.py
@@ -24,6 +24,10 @@ import os
 import sys
 import numpy as np
 from scipy.integrate import cumtrapz
+from collections import OrderedDict
+from openquake.hazardlib.geo import (PlanarSurface, SimpleFaultSurface,
+                                     ComplexFaultSurface, MultiSurface,
+                                     Point, Line)
 import matplotlib.pyplot as plt
 
 if sys.version_info[0] >= 3:
@@ -158,3 +162,165 @@ def load_pickle(pickle_file):
         print('Unable to load data ', pickle_file, ':', e)
         raise
     return pickle_data
+
+
+# Set of modules for converting OpenQuake surface classes to dictionaries
+def planar_fault_surface_to_dict(surface):
+    """
+    Parses a PlanarSurface object to a dictionary formatted for json export
+    """
+    output = OrderedDict([("type", "PlanarSurface")])
+    # Top left
+    for i, key in zip([0, 1, 3, 2],
+        ["top_left", "top_right", "bottom_right", "bottom_left"]):
+        output[key] = [surface.corner_lons[i],
+                       surface.corner_lats[i],
+                       surface.corner_depths[i]]
+    return output
+
+
+def simple_fault_surface_to_dict(surface):
+    """
+    Parsers a SimpleFaultSurface object ot a dictionary formatted for
+    json export
+
+    More complicated here as we need to use the surface nodes
+    """
+    output = OrderedDict([("type", "SimpleFaultSurface")])
+    for node in surface.surface_nodes[0]:
+        if "LineString" in node.tag:
+            trace = node[0].text
+            output["trace"] = [[trace[i], trace[i + 1]]
+                                for i in range(0, len(trace), 2)]
+        else:
+            output[node.tag] = node.text
+    return output
+
+
+def complex_fault_surface_to_dict(surface):
+    """
+    Parses a ComplexFaultSurface object ot a dictionary formatted for json
+    export
+    """
+    output = OrderedDict([("type", "ComplexFaultSurface")])
+    intermediate_edges = []
+    for node in surface.surface_nodes[0]:
+        edge = node[0].nodes[0].text
+        edge = [[edge[i], edge[i + 1], edge[i + 2]]
+                for i in range(0, len(edge), 3)]
+        if "intermediateEdge" in node.tag:
+            intermediate_edges.append(edge)
+        else:
+            output[node.tag] = edge
+    output["intermediateEdges"] = intermediate_edges
+    return output
+
+
+surfaces_to_dict = {
+    "PlanarSurface": planar_fault_surface_to_dict,
+    "SimpleFaultSurface": simple_fault_surface_to_dict,
+    "ComplexFaultSurface": complex_fault_surface_to_dict,
+    }
+
+
+def multi_surface_to_dict(surface):
+    """
+    Parses a multi
+    """
+    output = OrderedDict([("type", "MultiSurface"), ("surfaces", [])])
+    for sfc in surface.surfaces:
+        output["surfaces"].append(
+            surfaces_to_dict[sfc.__class__.__name__](sfc))
+    return output
+
+
+surfaces_to_dict["MultiSurface"] = multi_surface_to_dict
+
+
+# Surfaces from json dict
+def planar_fault_surface_from_dict(data, mesh_spacing=1.):
+    """
+    Builds a planar fault surface from the json load
+    """
+    assert "PlanarSurface" in data
+    top_left = Point(data["top_left"][0],
+                     data["top_left"][1],
+                     data["top_left"][2])
+    top_right = Point(data["top_right"][0],
+                      data["top_right"][1],
+                      data["top_right"][2])
+    bottom_left = Point(data["bottom_left"][0],
+                        data["bottom_left"][1],
+                        data["bottom_left"][2])
+    bottom_right = Point(data["bottom_right"][0],
+                         data["bottom_right"][1],
+                         data["bottom_right"][2])
+    return PlanarSurface.from_corner_points(mesh_spacing, top_left, top_right,
+                                            bottom_right, bottom_left)
+
+def simple_fault_surface_from_dict(data, mesh_spacing=1.):
+    """
+    Builds a simple fault surface from the json load
+    """
+    assert "SimpleFaultSurface" in data
+    trace = []
+    for lon, lat in data["trace"]:
+        trace.append(Point(lon, lat, 0.0))
+    trace = Line(trace)
+    return SimpleFaultSurface.from_fault_data(trace, data["upperSeismoDepth"],
+                                              data["lowerSeismoDepth"],
+                                              data["dip"], mesh_spacing)
+
+def _3d_line_from_list(vals):
+    """
+    """
+    vertices = []
+    for lon, lat, depth in vals:
+        vertices.append(Point(lon, lat, depth))
+    return Line(vertices)
+
+def complex_fault_surface_from_dict(data, mesh_spacing=1.):
+    """
+    Builds a complex fault surface from the json load
+    """
+    assert "ComplexFaultSurface" in data
+    edges = [_3d_line_from_list(data["faultTopEdge"])]
+    if len(data["intermediateEdges"]):
+        for iedge in data["intermediateEdges"]:
+            edges.append(_3d_line_from_list(iedge))
+    edges.append(_3d_line_from_list(data["faultBottomEdge"]))
+    return ComplexFaultSurface.from_fault_data(edges, mesh_spacing)
+
+surfaces_from_dict = {
+    "PlanarSurface": planar_fault_surface_from_dict,
+    "SimpleFaultSurface": simple_fault_surface_from_dict,
+    "ComplexFaultSurface": complex_fault_surface_from_dict}
+
+def multi_surface_from_dict(data, mesh_spacing=1.):
+    """
+    Builds a multi-fault surface from the json load
+    """
+    assert "MultiSurface" in data
+    surfaces = []
+    for surface in data["surfaces"]:
+        surfaces.append(surfaces_from_dict[surface["type"]](surface,
+                                                            mesh_spacing))
+    return MultiSurface(surfaces)
+
+surfaces_from_dict["MultiSurface"] = multi_surface_from_dict
+
+
+
+    
+
+
+    
+
+
+#surfaces_to_dict = {
+#    "PlanarSurface": planar_fault_surface_to_dict,
+#    "SimpleFaultSurface": simple_fault_surface_to_dict,
+#    "ComplexFaultSurface": complex_fault_surface_to_dict,
+#    "MultiSurface": multi_surface_to_dict
+#    }
+

--- a/tests/database_io_test.py
+++ b/tests/database_io_test.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2014-2017 GEM Foundation and G. Weatherill
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+"""
+Tests the IO of a database between pickle and json
+"""
+import os
+import shutil
+import sys
+import json
+import pprint
+import unittest
+from smtk import load_database
+from smtk.parsers.esm_flatfile_parser import ESMFlatfileParser
+
+if sys.version_info[0] >= 3:
+    import pickle
+else:
+    import cPickle as pickle
+
+def compare_two_json_files(file1, file2):
+    """
+    Compares two json files by parsing them into strings
+    """
+    # Load both jsons
+    with open(file1, "r") as f1:
+        data1 = json.load(f1)
+    with open(file2, "r") as f2:
+        data2 = json.load(f2)
+    # Print them as strings
+    d1 = pprint.pformat(data1)
+    d2 = pprint.pformat(data2)
+    # cleanup whitespace
+    d1 = d1.replace(" ", "")
+    d2 = d2.replace(" ", "")
+    n1, n2 = len(d1), len(d2)
+    for i in range(max(n1, n2)):
+        if not d1[i] == d2[i]:
+            # Is a mismatch - print the surrounding info
+            print(i, d1[(i - 20):(i+20)], d2[(i - 20):(i + 20)])
+            return False
+    return True
+
+
+BASE_DATA_PATH = os.path.join(
+    os.path.join(os.path.dirname(__file__), "parsers"), "data"
+    )
+
+class DatabaseLoadingTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pkl_dir = "esm_as_pickle"
+        #os.mkdir(cls.pkl_dir)
+        cls.json_dir = "esm_as_json"
+        os.mkdir(cls.json_dir)
+        cls.input_file = os.path.join(BASE_DATA_PATH,
+                                      "esm_flatfile_sample_file.csv")
+        # Build the database
+        _ = ESMFlatfileParser.autobuild("000", "DUMMY",
+                                        cls.pkl_dir,
+                                        cls.input_file)
+
+    def test_json_io_roundtrip(self):
+        # Load the db from pickle
+        db = load_database(self.pkl_dir)
+        # Export to json
+        file1 = os.path.join(self.json_dir, "metadatafile.json")
+        with open(file1, "w") as fi1:
+            fi1.write(db.to_json())
+        # Load from json
+        db1 = load_database(self.json_dir)
+        # Dump back to a json file
+        file2 = os.path.join(self.json_dir, "test_dump.json")
+        with open(file2, "w") as fi2:
+            fi2.write(db1.to_json())
+        # Now compare files
+        self.assertTrue(compare_two_json_files(file1, file2))
+
+    @classmethod
+    def tearDownClass(cls):
+        # Remove the directories
+        shutil.rmtree(cls.pkl_dir)
+        shutil.rmtree(cls.json_dir)


### PR DESCRIPTION
Addresses issue https://github.com/GEMScienceTools/gmpe-smtk/issues/79, which raised the idea of using json as an alternative and transferable means of storing the metadata of the strong motion database.

Several changes:
1. Adds methods to all `sm_database` objects to dump and/or instantiate the data to a dictionary
2. Adds methods to `sm_utils` for deadling with the different OpenQuake rupture object typologies in the case that a rupture surface is present
3. Adds a general `load_database` method that allows the user to load a database simply from the database directory path - adopting .pkl or .json depending on what format the metadata file found is.
4. Tests for json IO