### PR TITLE
Coordinates

### DIFF
--- a/smtk/parsers/asa_database_parser.py
+++ b/smtk/parsers/asa_database_parser.py
@@ -306,7 +306,7 @@ class ASADatabaseMetadataReader(SMDatabaseReader):
             eq_id,
             eq_name,
             eq_datetime,
-            -1*get_float(metadata["COORDENADAS DEL EPICENTRO"].split(" ")[3]),
+            -get_float(metadata["COORDENADAS DEL EPICENTRO"].split(" ")[3]),
             get_float(metadata["COORDENADAS DEL EPICENTRO"].split(" ")[0]),
             evtdepth,
             pref_mag,
@@ -323,11 +323,11 @@ class ASADatabaseMetadataReader(SMDatabaseReader):
         are converted to negative values.
         """
 
-        epi_lon = -1*get_float(
+        epi_lon = -get_float(
             metadata["COORDENADAS DEL EPICENTRO"].split(" ")[3])
         epi_lat = get_float(
             metadata["COORDENADAS DEL EPICENTRO"].split(" ")[0])
-        sta_lon = -1*get_float(
+        sta_lon = -get_float(
             metadata["COORDENADAS DE LA ESTACION"].split(" ")[3])
         sta_lat = get_float(
             metadata["COORDENADAS DE LA ESTACION"].split(" ")[0])
@@ -360,7 +360,7 @@ class ASADatabaseMetadataReader(SMDatabaseReader):
                     metadata["CLAVE DE LA ESTACION"]]),
             metadata["CLAVE DE LA ESTACION"],
             metadata["NOMBRE DE LA ESTACION"],
-            -1*get_float(metadata["COORDENADAS DE LA ESTACION"].split(" ")[3]),
+            -get_float(metadata["COORDENADAS DE LA ESTACION"].split(" ")[3]),
             get_float(metadata["COORDENADAS DE LA ESTACION"].split(" ")[0]),
             altitude)
 

--- a/smtk/parsers/asa_database_parser.py
+++ b/smtk/parsers/asa_database_parser.py
@@ -318,14 +318,16 @@ class ASADatabaseMetadataReader(SMDatabaseReader):
     def _parse_distance_data(self, metadata, file_str, eqk):
         """
         Parses the event metadata to return an instance of the :class:
-        smtk.sm_database.RecordDistance
+        smtk.sm_database.RecordDistance. Coordinates are provided in
+        terms of N, S, E, W direction, and longitude values must be
+        made negative.
         """
 
-        epi_lon = get_float(
+        epi_lon = -1*get_float(
             metadata["COORDENADAS DEL EPICENTRO"].split(" ")[3])
         epi_lat = get_float(
             metadata["COORDENADAS DEL EPICENTRO"].split(" ")[0])
-        sta_lon = get_float(
+        sta_lon = -1*get_float(
             metadata["COORDENADAS DE LA ESTACION"].split(" ")[3])
         sta_lat = get_float(
             metadata["COORDENADAS DE LA ESTACION"].split(" ")[0])

--- a/smtk/parsers/asa_database_parser.py
+++ b/smtk/parsers/asa_database_parser.py
@@ -178,7 +178,8 @@ class ASADatabaseMetadataReader(SMDatabaseReader):
     def _parse_event(self, metadata, file_str):
         """
         Parses the event metadata to return an instance of the :class:
-        smtk.sm_database.Earthquake
+        smtk.sm_database.Earthquake. Coordinates in western hemisphere
+        are returned as negative values.
         """
 
         months = {'ENERO': 1, 'FEBRERO': 2, 'MARZO': 3, 'ABRIL': 4, 'MAYO': 5,
@@ -305,7 +306,7 @@ class ASADatabaseMetadataReader(SMDatabaseReader):
             eq_id,
             eq_name,
             eq_datetime,
-            get_float(metadata["COORDENADAS DEL EPICENTRO"].split(" ")[3]),
+            -1*get_float(metadata["COORDENADAS DEL EPICENTRO"].split(" ")[3]),
             get_float(metadata["COORDENADAS DEL EPICENTRO"].split(" ")[0]),
             evtdepth,
             pref_mag,
@@ -318,9 +319,8 @@ class ASADatabaseMetadataReader(SMDatabaseReader):
     def _parse_distance_data(self, metadata, file_str, eqk):
         """
         Parses the event metadata to return an instance of the :class:
-        smtk.sm_database.RecordDistance. Coordinates are provided in
-        terms of N, S, E, W direction, and longitude values must be
-        made negative.
+        smtk.sm_database.RecordDistance. Coordinates in western hemisphere
+        are converted to negative values.
         """
 
         epi_lon = -1*get_float(
@@ -347,7 +347,8 @@ class ASADatabaseMetadataReader(SMDatabaseReader):
 
     def _parse_site_data(self, metadata):
         """
-        Parses the site metadata
+        Parses the site metadata. Coordinates in western hemisphere
+        are returned as negative values.
         """
         try:
             altitude = get_float(metadata["ALTITUD (msnm)"])
@@ -359,7 +360,7 @@ class ASADatabaseMetadataReader(SMDatabaseReader):
                     metadata["CLAVE DE LA ESTACION"]]),
             metadata["CLAVE DE LA ESTACION"],
             metadata["NOMBRE DE LA ESTACION"],
-            get_float(metadata["COORDENADAS DE LA ESTACION"].split(" ")[3]),
+            -1*get_float(metadata["COORDENADAS DE LA ESTACION"].split(" ")[3]),
             get_float(metadata["COORDENADAS DE LA ESTACION"].split(" ")[0]),
             altitude)
 

--- a/tests/parsers/asa_parser_test.py
+++ b/tests/parsers/asa_parser_test.py
@@ -36,7 +36,7 @@ class ASA_MetadataParsertest(unittest.TestCase):
         for i in self.database.records:
             parsed_lats.append(str(i.event.latitude))
         self.assertEqual(valid.longitudes(','.join(parsed_lons)),
-                         [101.089, 115.33])
+                         [-101.089, -115.33])
         self.assertEqual(valid.latitudes(','.join(parsed_lats)),
                          [17.446, 32.32])
 

--- a/tests/parsers/asa_parser_test.py
+++ b/tests/parsers/asa_parser_test.py
@@ -48,7 +48,7 @@ class ASA_MetadataParsertest(unittest.TestCase):
         for i in self.database.records:
             parsed_lats.append(str(i.site.latitude))
         self.assertEqual(valid.longitudes(','.join(parsed_lons)),
-                         [99.85157, 116.301])
+                         [-99.85157, -116.301])
         self.assertEqual(valid.latitudes(','.join(parsed_lats)),
                          [16.84851, 32.02])
 


### PR DESCRIPTION
The coordinates in the ASA files are given in terms of N S E W directions. Coordinates in the western hemisphere (i.e. Mexico) should be made negative to be consistent with the OQ convention.