### PR TITLE
implements 'from_rupture_properties' methods in Trellis classes

### DIFF
--- a/smtk/trellis/configure.py
+++ b/smtk/trellis/configure.py
@@ -680,13 +680,27 @@ class GSIMRupture(object):
                                             vs30measured, z1pt0, z2pt5,
                                             backarc)
 
-        distances = np.asarray(distances) if not as_log \
-            else np.log10(distances)
+        distances = self._convert_distances(distances, as_log)
 
         return self._append_target_sites(distances, azimuth, origin_location,
                                          vs30, line_azimuth, origin_point,
                                          as_log, vs30measured, z1pt0, z2pt5,
                                          backarc)
+
+    @staticmethod
+    def _convert_distances(distances, as_log=False):
+        '''assures distances is a numpy numeric array, sorts it
+        and converts its value to a logaritmic scale preserving the array
+        bounds (min and max)'''
+        dist = np.asarray(distances)
+        dist.sort()
+        if as_log:
+            oldmin, oldmax = dist[0], dist[-1]
+            dist = np.log1p(dist)  # avoid -inf @ zero in case
+            newmin, newmax = dist[0], dist[-1]
+            # re-map the space to be logarithmic between oldmin and oldmax:
+            dist = oldmin + (oldmax-oldmin)*(dist - newmin)/(newmax - newmin)
+        return dist
 
     def _define_origin_target_site(self, vs30, line_azimuth=90.,
                                    origin_point=(0.5, 0.5), vs30measured=True,

--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -822,12 +822,12 @@ class DistanceIMTTrellis(MagnitudeIMTTrellis):
 
         :param distances: a numeric array of chosen distances
         '''
-        params = {k: properties[k] for k in ['dip', 'rake', 'initial_point',
-                                             'hypocentre_location', 'aspect',
-                                             'ztor', 'strike', 'msr',
-                                             'tectonic_region']
+        params = {k: properties[k] for k in ['rake', 'initial_point', 'ztor',
+                                             'hypocentre_location', 'strike',
+                                             'msr', 'tectonic_region']
                   if k in properties}
-        rupture = GSIMRupture(magnitude, **params)
+        rupture = GSIMRupture(magnitude, properties['dip'],
+                              properties['aspect'], **params)
 
         params = {k: properties[k] for k in ['line_azimuth', 'as_log',
                                              'vs30measured', 'z1pt0', 'z2pt5',

--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -829,11 +829,12 @@ class DistanceIMTTrellis(MagnitudeIMTTrellis):
                   if k in properties}
         rupture = GSIMRupture(magnitude, **params)
 
-        params = {k: properties[k] for k in ['vs30', 'line_azimuth', 'as_log',
+        params = {k: properties[k] for k in ['line_azimuth', 'as_log',
                                              'vs30measured', 'z1pt0', 'z2pt5',
                                              'origin_point', 'backarc']
                   if k in properties}
         rupture.get_target_sites_line_from_given_distances(distances,
+                                                           properties['vs30'],
                                                            **params)
 
         return cls.from_rupture_model(rupture, gsims, imts,

--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -410,6 +410,17 @@ class MagnitudeIMTTrellis(BaseTrellis):
             imts, params, stddevs, **kwargs)
 
     @classmethod
+    def from_rupture_properties(cls, properties, magnitudes, distance,
+                                gsims, imts, stddevs='Total', **kwargs):
+        '''Constructs the Base Trellis Class from a dictionary of
+        properties. In this class, this method is simply an alias of
+        `from_rupture_model`
+        '''
+        return cls.from_rupture_model(properties, magnitudes, distance,
+                                      gsims, imts, stddevs=stddevs,
+                                      **kwargs)
+
+    @classmethod
     def from_rupture_model(cls, properties, magnitudes, distance, gsims, imts,
                            stddevs='Total', **kwargs):
         """
@@ -800,7 +811,34 @@ class DistanceIMTTrellis(MagnitudeIMTTrellis):
 
         super(DistanceIMTTrellis, self).__init__(magnitudes, distances, gsims,
             imts, params, stddevs, **kwargs)
-    
+
+    @classmethod
+    def from_rupture_properties(cls, properties, magnitude, distances,
+                                gsims, imts, stddevs='Total', **kwargs):
+        '''Constructs the Base Trellis Class from a rupture properties.
+        It internally creates a Rupture object and calls
+        `from_rupture_model`. When not listed, arguments take the same
+        values as `from_rupture_model`
+
+        :param distances: a numeric array of chosen distances
+        '''
+        params = {k: properties[k] for k in ['dip', 'rake', 'initial_point',
+                                             'hypocentre_location', 'aspect',
+                                             'ztor', 'strike', 'msr',
+                                             'tectonic_region']
+                  if k in properties}
+        rupture = GSIMRupture(magnitude, **params)
+
+        params = {k: properties[k] for k in ['vs30', 'line_azimuth', 'as_log',
+                                             'vs30measured', 'z1pt0', 'z2pt5',
+                                             'origin_point', 'backarc']
+                  if k in properties}
+        rupture.get_target_sites_line_from_given_distances(distances,
+                                                           **params)
+
+        return cls.from_rupture_model(rupture, gsims, imts,
+                                      stddevs=stddevs, **kwargs)
+
     @classmethod
     def from_rupture_model(cls, rupture, gsims, imts, stddevs='Total',
             **kwargs):
@@ -1202,6 +1240,17 @@ class MagnitudeDistanceSpectraTrellis(BaseTrellis):
                     dist_check = True
                 setattr(dctx, dist, distance[dist])
             self.dctx.append(dctx)
+
+    @classmethod
+    def from_rupture_properties(cls, properties, magnitudes, distance,
+                                gsims, imts, stddevs='Total', **kwargs):
+        '''Constructs the Base Trellis Class from a dictionary of
+        properties. In this class, this method is simply an alias of
+        `from_rupture_model`
+        '''
+        return cls.from_rupture_model(properties, magnitudes, distance,
+                                      gsims, imts, stddevs=stddevs,
+                                      **kwargs)
 
     @classmethod
     def from_rupture_model(cls, properties, magnitudes, distances,

--- a/tests/trellis/trellis_test_from_properties.py
+++ b/tests/trellis/trellis_test_from_properties.py
@@ -33,7 +33,8 @@ BASE_DATA_PATH = os.path.join(os.path.dirname(__file__), "data")
 class BaseTrellisTest(unittest.TestCase):
     """
     This core test is designed to run a series of trellis plot calculations
-    and ensure compatibility with previously generated results
+    and ensure compatibility with previously generated results by using
+    the `from_rupture_properties` methods of each Trellis class
     """
 
     TEST_FILE = None
@@ -84,14 +85,17 @@ class BaseTrellisTest(unittest.TestCase):
 class DistanceTrellisTest(BaseTrellisTest):
     TEST_FILE = "test_distance_imt_trellis.json"
 
-    def _run_trellis(self, rupture):
+    def _run_trellis(self, magnitude, distances, properties):
         """
         Executes the trellis plotting - for mean
         """
-        return trpl.DistanceIMTTrellis.from_rupture_model(rupture,
-                                                          self.gsims,
-                                                          self.imts,
-                                                          distance_type="rrup")
+        return trpl.DistanceIMTTrellis.from_rupture_properties(
+            properties,
+            magnitude,
+            distances,
+            self.gsims,
+            self.imts,
+            distance_type="rrup")
 
     def test_distance_imt_trellis(self):
         """
@@ -100,11 +104,12 @@ class DistanceTrellisTest(BaseTrellisTest):
         reference = json.load(open(
             os.path.join(BASE_DATA_PATH, self.TEST_FILE), "r"))
         # Setup rupture
-        rupture = rcfg.GSIMRupture(6.5, 60., 1.5,
-                                   hypocentre_location=(0.5, 0.5))
-        rupture.get_target_sites_line(250.0, 1.0, 800.0)
+        properties = dict(dip=60.0, aspect=1.5, hypocentre_location=(0.5, 0.5),
+                          vs30=800)
+        distances = np.arange(0, 250.5, 1)
+        magnitude = 6.5
         # Get trellis calculations
-        trl = self._run_trellis(rupture)
+        trl = self._run_trellis(magnitude, distances, properties)
         # Parse the json formatted string to a dictionary string
         results = json.loads(trl.to_json())
         # Compare the two dictionaries
@@ -114,12 +119,14 @@ class DistanceTrellisTest(BaseTrellisTest):
 class DistanceSigmaTrellisTest(DistanceTrellisTest):
     TEST_FILE = "test_distance_sigma_imt_trellis.json"
 
-    def _run_trellis(self, rupture):
+    def _run_trellis(self, magnitude, distances, properties):
         """
         Executes the trellis plotting - for standard deviation
         """
-        return trpl.DistanceSigmaIMTTrellis.from_rupture_model(
-            rupture,
+        return trpl.DistanceSigmaIMTTrellis.from_rupture_properties(
+            properties,
+            magnitude,
+            distances,
             self.gsims,
             self.imts,
             distance_type="rrup")
@@ -132,11 +139,12 @@ class MagnitudeTrellisTest(BaseTrellisTest):
         """
         Executes the trellis plotting - for mean
         """
-        return trpl.MagnitudeIMTTrellis.from_rupture_model(properties,
-                                                           magnitudes,
-                                                           distance,
-                                                           self.gsims,
-                                                           self.imts)
+        return trpl.MagnitudeIMTTrellis.from_rupture_properties(
+            properties,
+            magnitudes,
+            distance,
+            self.gsims,
+            self.imts)
 
     def test_magnitude_imt_trellis(self):
         """
@@ -161,11 +169,12 @@ class MagnitudeSigmaTrellisTest(MagnitudeTrellisTest):
         """
         Executes the trellis plotting - for standard deviation
         """
-        return trpl.MagnitudeSigmaIMTTrellis.from_rupture_model(properties,
-                                                                magnitudes,
-                                                                distance,
-                                                                self.gsims,
-                                                                self.imts)
+        return trpl.MagnitudeSigmaIMTTrellis.from_rupture_properties(
+            properties,
+            magnitudes,
+            distance,
+            self.gsims,
+            self.imts)
 
 
 class MagnitudeDistanceSpectraTrellisTest(BaseTrellisTest):
@@ -203,7 +212,7 @@ class MagnitudeDistanceSpectraTrellisTest(BaseTrellisTest):
         """
         Executes the trellis plotting - for mean
         """
-        return trpl.MagnitudeDistanceSpectraTrellis.from_rupture_model(
+        return trpl.MagnitudeDistanceSpectraTrellis.from_rupture_properties(
             properties, magnitudes, distances, self.gsims, self.periods,
             distance_type="rrup")
 
@@ -231,7 +240,7 @@ class MagnitudeDistanceSpectraSigmaTrellisTest(
         """
         Executes the trellis plotting - for standard deviation
         """
-        return trpl.MagnitudeDistanceSpectraSigmaTrellis.from_rupture_model(
+        return trpl.MagnitudeDistanceSpectraSigmaTrellis.from_rupture_properties(
             properties, magnitudes, distances, self.gsims, self.periods,
             distance_type="rrup")
 


### PR DESCRIPTION
TBD:
- Check function names (I inferred from the code, there might be better scientific names, maybe )
- '_append_target_sites' where I set the 'spacing' key for given distances (hope it makes sense).
- Tests: I tested with the newly implemented test 'trellis_test_from_properties' which is a modification of the original 'trellis_test' (which does not break). I did not run all other tests though.