### PR TITLE
Bug fix(es) in trellis_plots.py

### DIFF
--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -21,8 +21,10 @@
 Sets up a simple rupture-site configuration to allow for physical comparison
 of GMPEs
 '''
-
-import re, json
+import os
+import sys
+import re
+import json
 import numpy as np
 from collections import Iterable, OrderedDict
 from cycler import cycler
@@ -616,11 +618,11 @@ class MagnitudeIMTTrellis(BaseTrellis):
                             self.dctx,
                             imt.from_string(i_m),
                             [self.stddevs])
-                       
+
                         gmvs[gmpe_name][i_m][iloc, :] = \
                             np.exp(means)
                     except (KeyError, ValueError):
-                        gmvs[gmpe_name][i_m] = []
+                        gmvs[gmpe_name][i_m] = np.array([], dtype=float)
                         break
         return gmvs
 
@@ -731,11 +733,11 @@ class MagnitudeSigmaIMTTrellis(MagnitudeIMTTrellis):
                              [self.stddevs])
                         gmvs[gmpe_name][i_m][iloc, :] = sigmas[0]
                     except KeyError:
-                        gmvs[gmpe_name][i_m] = []
+                        gmvs[gmpe_name][i_m] = np.array([], dtype=float)
                         break
 
         return gmvs
-    
+
     def get_ground_motion_values_from_rupture(self):
         """
         """
@@ -758,7 +760,7 @@ class MagnitudeSigmaIMTTrellis(MagnitudeIMTTrellis):
 
                         gmvs[gmpe_name][i_m][iloc, :] = sigmas[0]
                     except (KeyError, ValueError):
-                        gmvs[gmpe_name][i_m] = []
+                        gmvs[gmpe_name][i_m] = np.array([], dtype=float)
                         break
         return gmvs
 
@@ -1043,7 +1045,7 @@ class DistanceSigmaIMTTrellis(DistanceIMTTrellis):
                              [self.stddevs])
                         gmvs[gmpe_name][i_m][iloc, :] = sigmas[0]
                     except (KeyError, ValueError):
-                        gmvs[gmpe_name][i_m] = []
+                        gmvs[gmpe_name][i_m] = np.array([], dtype=float)
                         break
                         
                         
@@ -1071,7 +1073,7 @@ class DistanceSigmaIMTTrellis(DistanceIMTTrellis):
 
                         gmvs[gmpe_name][i_m][iloc, :] = sigmas[0]
                     except KeyError:
-                        gmvs[gmpe_name][i_m] = []
+                        gmvs[gmpe_name][i_m] = np.array([], dtype=float)
                         break
         return gmvs
 
@@ -1376,7 +1378,7 @@ class MagnitudeDistanceSpectraTrellis(BaseTrellis):
                         gmvs[gmpe_name][i_m][iloc, :] = \
                             np.exp(means)
                     except (KeyError, ValueError):
-                        gmvs[gmpe_name][i_m] = []
+                        gmvs[gmpe_name][i_m] = np.array([], dtype=float)
                         break
         return gmvs
 
@@ -1649,7 +1651,7 @@ class MagnitudeDistanceSpectraSigmaTrellis(MagnitudeDistanceSpectraTrellis):
                              [self.stddevs])
                         gmvs[gmpe_name][i_m][iloc, :] = sigmas[0]
                     except (KeyError, ValueError):
-                        gmvs[gmpe_name][i_m] = []
+                        gmvs[gmpe_name][i_m] = np.array([], dtype=float)
                         break
         return gmvs
 

--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -1161,6 +1161,10 @@ class MagnitudeDistanceSpectraTrellis(BaseTrellis):
 
         In this case the class is instantiated with a set of magnitudes
         and a dictionary indicating the different distance types.
+
+        :param imts: (numeric list or numpy array)
+            the Spectral Acceleration's
+            natural period(s) to be used
         """
         imts = ["SA(%s)" % i_m for i_m in imts]
 
@@ -1241,13 +1245,19 @@ class MagnitudeDistanceSpectraTrellis(BaseTrellis):
 
     @classmethod
     def from_rupture_properties(cls, properties, magnitudes, distance,
-                                gsims, imts, stddevs='Total', **kwargs):
+                                gsims, periods, stddevs='Total', **kwargs):
         '''Constructs the Base Trellis Class from a dictionary of
         properties. In this class, this method is simply an alias of
         `from_rupture_model`
+
+        :param periods: (numeric list or numpy array)
+            the Spectral Acceleration's
+            natural period(s) to be used. Note that this parameter
+            is called `imt` in `from_rupture_model` where the name
+            `imt` has been kept for legacy code compatibility
         '''
         return cls.from_rupture_model(properties, magnitudes, distance,
-                                      gsims, imts, stddevs=stddevs,
+                                      gsims, periods, stddevs=stddevs,
                                       **kwargs)
 
     @classmethod

--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -1491,8 +1491,10 @@ class MagnitudeDistanceSpectraTrellis(BaseTrellis):
                 for gsim in gmvs:
                     for imt in self.imts:
                         if len(gmvs[gsim][imt]):
-                            ydict["yvalues"][gsim].\
-                                append(gmvs[gsim][imt][i, j])
+                            value = gmvs[gsim][imt][i, j]
+                            if np.isnan(value):
+                                value = None
+                            ydict["yvalues"][gsim].append(value)
                         else:
                             ydict["yvalues"][gsim].append(None)
                 gmv_dict["figures"].append(ydict)

--- a/tests/trellis/trellis_test_todict.py
+++ b/tests/trellis/trellis_test_todict.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2014-2017 GEM Foundation and G. Weatherill
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+"""
+Tests for generation of data for trellis plots
+"""
+import unittest
+import os
+import json
+import numpy as np
+from openquake.hazardlib.geo import Point
+from openquake.hazardlib.scalerel import get_available_magnitude_scalerel
+import smtk.trellis.trellis_plots as trpl
+from smtk.trellis.configure import vs30_to_z1pt0_cy14, vs30_to_z2pt5_cb14
+
+
+class BaseTrellisTest(unittest.TestCase):
+    """
+    Rationale: the to_dict method of Distance Trellis plots
+    failed to "dictionarize" empty yvalues arrays:
+    The method(s) `get_ground_motion_values*`
+    were returning different types: numpy arrays or empty
+    lists. The fix was to return empty numpy arrays instead.
+    This test assures the fix did work properly and it does
+    not raises, returning the empty expected list
+    """
+
+    # TEST_FILE = None
+
+    def setUp(self):
+        self.imts = ["PGA", "PGV"]
+        self.periods = [0.05, 0.075, 0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16,
+                        0.17, 0.18, 0.19, 0.20, 0.22, 0.24, 0.26, 0.28, 0.30,
+                        0.32, 0.34, 0.36, 0.38, 0.40, 0.42, 0.44, 0.46, 0.48,
+                        0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95,
+                        1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0,
+                        3.0, 4.001, 5.0, 7.5, 10.0]
+
+        self.gsims = ["AbrahamsonEtAl2014", "AbrahamsonEtAl2014NSHMPLower",
+                      "AbrahamsonEtAl2014NSHMPMean",
+                      "AbrahamsonEtAl2014NSHMPUpper",
+                      "AbrahamsonEtAl2014RegCHN",
+                      "AbrahamsonEtAl2014RegJPN",
+                      "AbrahamsonEtAl2014RegTWN",
+                      "AkkarBommer2010SWISS01",
+                      "AkkarBommer2010SWISS04",
+                      "AkkarBommer2010SWISS08",
+                      "AkkarEtAl2013", "AkkarEtAlRepi2014"]
+
+        # this set of parameters raised exceptions, as e.g.
+        # AkkarBommer2010SWISS01's PGV eas empty
+        vs30 = 760.0
+        self.params = {"magnitude": np.array([3, 4]),
+                       "distance": np.array([10, 11, 12]),
+                       "dip": 60, "aspect": 1.5, "rake": 0.0, "ztor": 0.0,
+                       "strike": 0.0,
+                       "msr": get_available_magnitude_scalerel()["WC1994"],
+                       "initial_point": Point(0, 0), "hypocentre_location": [0.5, 0.5],
+                       "vs30": vs30, "vs30_measured": True,
+                       "line_azimuth": 0.0, "backarc": False,
+                       "z1pt0": vs30_to_z1pt0_cy14(vs30),
+                       "z2pt5": vs30_to_z2pt5_cb14(vs30)}
+
+
+class DistanceTrellisTest(BaseTrellisTest):
+
+    def _run_trellis(self, magnitude, distances, properties):
+        """
+        Executes the trellis plotting - for mean
+        """
+        return trpl.DistanceIMTTrellis.from_rupture_properties(
+            properties,
+            magnitude,
+            distances,
+            self.gsims,
+            self.imts,
+            distance_type="rrup")
+
+    def test_distance_imt_trellis(self):
+        """
+        Tests the DistanceIMT trellis data generation
+        """
+        # Setup rupture
+        properties = {k: self.params[k]
+                      for k in ['dip', 'aspect',
+                                'hypocentre_location', 'vs30']}
+        distances = self.params['distance']
+        magnitude = self.params['magnitude'][0]
+        # Get trellis calculations
+        trl = self._run_trellis(magnitude, distances, properties)
+        # simply run the to_dict to assure it does not raise:
+        figures = trl.to_dict()['figures']
+        self.assertEqual(figures[1]['yvalues']['AkkarBommer2010SWISS01'],
+                         [])
+
+
+class DistanceSigmaTrellisTest(DistanceTrellisTest):
+    TEST_FILE = "test_distance_sigma_imt_trellis.json"
+ 
+    def _run_trellis(self, magnitude, distances, properties):
+        """
+        Executes the trellis plotting - for standard deviation
+        """
+        return trpl.DistanceSigmaIMTTrellis.from_rupture_properties(
+            properties,
+            magnitude,
+            distances,
+            self.gsims,
+            self.imts,
+            distance_type="rrup")
+
+# We did not spot a set of parameters for which we have empty
+# yvalues in case of MagnitudeTrellis and MagnitudeDistanceSpectra Trellis
+# thus the set of classes below is commented (for the moment?)
+
+# class MagnitudeTrellisTest(BaseTrellisTest):
+# 
+#     def _run_trellis(self, magnitudes, distance, properties):
+#         """
+#         Executes the trellis plotting - for mean
+#         """
+#         return trpl.MagnitudeIMTTrellis.from_rupture_properties(
+#             properties,
+#             magnitudes,
+#             distance,
+#             self.gsims,
+#             self.imts)
+# 
+#     def test_magnitude_imt_trellis(self):
+#         """
+#         Tests the MagnitudeIMT trellis data generation
+#         """
+#         magnitudes = self.params['magnitude']
+#         distance = self.params['distance'][0]
+#         properties = {k: self.params[k] for k in
+#                       ["dip", "rake", "aspect", "ztor",
+#                        "vs30", "backarc", "z1pt0",
+#                        "z2pt5", "line_azimuth"]}
+#         trl = self._run_trellis(magnitudes, distance, properties)
+#         # simply run the to_dict to assure it does not raise:
+#         trl.to_dict()
+# 
+# 
+# class MagnitudeSigmaTrellisTest(MagnitudeTrellisTest):
+# 
+#     def _run_trellis(self, magnitudes, distance, properties):
+#         """
+#         Executes the trellis plotting - for standard deviation
+#         """
+#         return trpl.MagnitudeSigmaIMTTrellis.from_rupture_properties(
+#             properties,
+#             magnitudes,
+#             distance,
+#             self.gsims,
+#             self.imts)
+# 
+# 
+# class MagnitudeDistanceSpectraTrellisTest(BaseTrellisTest):
+#
+#     def _run_trellis(self, magnitudes, distances, properties):
+#         """
+#         Executes the trellis plotting - for mean
+#         """
+#         return trpl.MagnitudeDistanceSpectraTrellis.from_rupture_properties(
+#             properties, magnitudes, distances, self.gsims, self.periods,
+#             distance_type="rrup")
+# 
+#     def test_magnitude_distance_spectra_trellis(self):
+#         """
+#         Tests the MagnitudeDistanceSpectra Trellis data generation
+#         """
+#         properties = {k: self.params[k] for k in
+#                       ["dip", "rake", "aspect", "ztor",
+#                        "vs30", "backarc", "z1pt0",
+#                        "z2pt5"]}
+#         magnitudes = self.params['magnitude']
+#         distances = self.params['distance']
+#         trl = self._run_trellis(magnitudes, distances, properties)
+#         dic = trl.to_dict()
+# 
+# 
+# class MagnitudeDistanceSpectraSigmaTrellisTest(
+#         MagnitudeDistanceSpectraTrellisTest):
+# 
+#     def _run_trellis(self, magnitudes, distances, properties):
+#         """
+#         Executes the trellis plotting - for standard deviation
+#         """
+#         return trpl.MagnitudeDistanceSpectraSigmaTrellis.from_rupture_properties(
+#             properties, magnitudes, distances, self.gsims, self.periods,
+#             distance_type="rrup")
+
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()


### PR DESCRIPTION
- Fixes: 
   1. a bug whereby empty Python lists where returned from within the `get_ground_motion_values*` methods. This lead to an `AttributeError` in the `to_dict` method trying to `flatten` a (empty) Python list. All `get_ground_motion_values*` now return `numpy` arrays.
  2. a bug whereby NaNs where encoded in the `to_dict` method of `MagnitudeDistance`* classes. Now None's are returned.

  Added test for the `Distance` trellis class for case 1 and `MagnitudeDistance` trellis class for case 2 (with the parameter set whereby I found the bugs). Missing tests for the `Magnitude` trellis class as I could not programmatically create the right parameter set.

- Fixed missing imports of `os` and `sys` forgot by some other contribution

- Changed the argument name `imt` of `from_rupture_parameter` in `MagnitudeDistance` class: now it's called `periods`, which is more meaningful to me. I did not change other methods because legacy code might rely on the old argument name, although I would strongly suggest to rename the parameter as it is not a list of `imt` but a numeric sequence of periods.
