### PR TITLE
Decouples residual plots data from matplotlib functions + tests + minor bug fixes

### DIFF
--- a/smtk/residuals/gmpe_residuals.py
+++ b/smtk/residuals/gmpe_residuals.py
@@ -655,7 +655,7 @@ class Likelihood(Residuals):
                           % (imtx, gmpe))
                     continue
                 lh_values[gmpe][imtx] = {}
-                values = self.get_likelihood_values_for(gmpe, imt)
+                values = self.get_likelihood_values_for(gmpe, imtx)
                 for res_type, data in values.items():
                     l_h, median_lh = data
                     lh_values[gmpe][imtx][res_type] = l_h

--- a/smtk/residuals/residual_plots.py
+++ b/smtk/residuals/residual_plots.py
@@ -21,12 +21,11 @@ import numpy as np
 from scipy.stats import linregress
 
 """
-Module holding functions returning GMPE residual plot data.
-All residual plot functions should return the same kind of object (dicts)
-with mandatory keys 'x', 'y', 'xlabel' , 'ylabel'. See their documentation
-for details.
+Module managing GMPE+IMT residual plot data.
 This module avoids the use of classes and inhertances as simple functions
 accomplish the task without unnecessary overhead.
+All non-private functions should return the same dicts (see docstrings
+for details)
 """
 
 
@@ -88,8 +87,8 @@ def _get_histogram_data(data, bin_width=0.5):
     return vals.astype(float), bins
 
 
-def residuals_lh_density_distribution(residuals, gmpe, imt, bin_width=0.1,
-                                      as_json=False):
+def likelihood_density_distribution(residuals, gmpe, imt, bin_width=0.1,
+                                    as_json=False):
     '''Returns the density distribution of the given gmpe and imt
 
     :param residuals:
@@ -102,8 +101,8 @@ def residuals_lh_density_distribution(residuals, gmpe, imt, bin_width=0.1,
     :return: a dict mapping each residual type (string, e.g. 'Intra event') to
     a dict with (at least) the mandatory keys 'x', 'y', 'xlabel', 'ylabel'
     representing the plot data.
-    Additional keys: 'mean' (float) and 'Std Dev' (float) representing
-    the mean and standard deviation of the data
+    Additional keys: 'median' (float) representing
+    the median of the data
     '''
     plot_data = {}
     data = residuals.get_likelihood_values_for(gmpe, imt)
@@ -347,8 +346,7 @@ def _get_depths(residuals, gmpe, imt, res_type):
     depths = np.array([])
     for i, ctxt in enumerate(residuals.contexts):
         if res_type == "Inter event":
-            nvals = np.ones(
-                len(residuals.unique_indices[gmpe][imt][i]))
+            nvals = np.ones(len(residuals.unique_indices[gmpe][imt][i]))
         else:
             nvals = np.ones(len(ctxt["Distances"].repi))
         # TODO This hack needs to be fixed!!!

--- a/smtk/residuals/residual_plots.py
+++ b/smtk/residuals/residual_plots.py
@@ -16,10 +16,6 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-
-import numpy as np
-from scipy.stats import linregress
-
 """
 Module managing GMPE+IMT residual plot data.
 This module avoids the use of classes and inhertances as simple functions
@@ -27,6 +23,9 @@ accomplish the task without unnecessary overhead.
 All non-private functions should return the same dicts (see docstrings
 for details)
 """
+
+import numpy as np
+from scipy.stats import linregress
 
 
 def _tojson(*numpy_objs):
@@ -87,9 +86,8 @@ def _get_histogram_data(data, bin_width=0.5):
     return vals.astype(float), bins
 
 
-def likelihood_density_distribution(residuals, gmpe, imt, bin_width=0.1,
-                                    as_json=False):
-    '''Returns the density distribution of the given gmpe and imt
+def likelihood(residuals, gmpe, imt, bin_width=0.1, as_json=False):
+    '''Returns the likelihood of the given gmpe and imt
 
     :param residuals:
             Residuals as instance of :class: smtk.gmpe_residuals.Likelihood
@@ -133,7 +131,7 @@ def _get_lh_histogram_data(lh_values, bin_width=0.1):
     return vals.astype(float), bins
 
 
-def residuals_vs_mag(residuals, gmpe, imt, as_json=False):
+def residuals_with_magnitude(residuals, gmpe, imt, as_json=False):
     '''Returns the residuals of the given gmpe and imt vs. magnitude
 
     :param residuals:
@@ -190,7 +188,7 @@ def _get_magnitudes(residuals, gmpe, imt, res_type):
     return magnitudes
 
 
-def residuals_vs_vs30(residuals, gmpe, imt, as_json=False):
+def residuals_with_vs30(residuals, gmpe, imt, as_json=False):
     '''Returns the residuals of the given gmpe and imt vs. vs30
 
     :param residuals:
@@ -242,8 +240,8 @@ def _get_vs30(residuals, gmpe, imt, res_type):
     return vs30
 
 
-def residuals_vs_dist(residuals, gmpe, imt, distance_type="rjb",
-                      as_json=False):
+def residuals_with_distance(residuals, gmpe, imt, distance_type="rjb",
+                            as_json=False):
     '''Returns the residuals of the given gmpe and imt vs. distance
 
     :param residuals:
@@ -300,7 +298,7 @@ def _get_distances(residuals, gmpe, imt, res_type, distance_type):
     return distances
 
 
-def residuals_vs_depth(residuals, gmpe, imt, as_json=False):
+def residuals_with_depth(residuals, gmpe, imt, as_json=False):
     '''Returns the residuals of the given gmpe and imt vs. depth
 
     :param residuals:

--- a/smtk/residuals/residual_plots.py
+++ b/smtk/residuals/residual_plots.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python 
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2014-2017 GEM Foundation and G. Weatherill
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+from scipy.stats import linregress
+
+"""
+Module holding functions returning GMPE residual plot data.
+All residual plot functions should return the same kind of object (dicts)
+with mandatory keys 'x', 'y', 'xlabel' , 'ylabel'. See their documentation
+for details.
+This module avoids the use of classes and inhertances as simple functions
+accomplish the task without unnecessary overhead.
+"""
+
+
+def _tojson(*numpy_objs):
+    '''Utility function which returns a list where each element of numpy_objs
+    is converted to its python equivalent (float or list)'''
+    # note: numpy.float64(N).tolist() returns a python float, so:
+    return tuple(_.tolist() for _ in numpy_objs)
+
+
+def residuals_density_distribution(residuals, gmpe, imt, bin_width=0.5,
+                                   as_json=False):
+    '''Returns the density distribution of the given gmpe and imt
+
+    :param residuals:
+            Residuals as instance of :class: smtk.gmpe_residuals.Residuals
+    :param gmpe: (string) the gmpe/gsim
+    :param imt: (string) the intensity measure type
+    :param as_json: when True, converts all numpy numeric values (scalar
+    and arrays) to their python equivalent. False by default
+
+    :return: a dict mapping each residual type (string, e.g. 'Intra event') to
+    a dict with (at least) the mandatory keys 'x', 'y', 'xlabel', 'ylabel'
+    representing the plot data.
+    Additional keys: 'mean' (float) and 'Std Dev' (float) representing
+    the mean and standard deviation of the data
+    '''
+    statistics = residuals.get_residual_statistics_for(gmpe, imt)
+    plot_data = {}
+    data = residuals.residuals[gmpe][imt]
+
+    for res_type in data.keys():
+
+        vals, bins = _get_histogram_data(data[res_type], bin_width=bin_width)
+
+        mean = statistics[res_type]["mean"]
+        stddev = statistics[res_type]["stddev"]
+        x = bins[:-1]
+        y = vals
+
+        if as_json:
+            mean, stddev, x, y = _tojson(mean, stddev, x, y)
+
+        plot_data[res_type] = \
+            {'x': x, 'y': y, 'mean': mean, 'stddev': stddev,
+             'xlabel': "Z (%s)" % imt, 'ylabel': "Frequency"}
+
+    return plot_data
+
+
+def _get_histogram_data(data, bin_width=0.5):
+    """
+    Retreives the histogram of the residuals
+    """
+    bins = np.arange(np.floor(np.min(data)),
+                     np.ceil(np.max(data)) + bin_width,
+                     bin_width)
+    vals = np.histogram(data, bins, density=True)[0]
+    return vals.astype(float), bins
+
+
+def residuals_lh_density_distribution(residuals, gmpe, imt, bin_width=0.1,
+                                      as_json=False):
+    '''Returns the density distribution of the given gmpe and imt
+
+    :param residuals:
+            Residuals as instance of :class: smtk.gmpe_residuals.Likelihood
+    :param gmpe: (string) the gmpe/gsim
+    :param imt: (string) the intensity measure type
+    :param as_json: when True, converts all numpy numeric values (scalar
+    and arrays) to their python equivalent. False by default
+
+    :return: a dict mapping each residual type (string, e.g. 'Intra event') to
+    a dict with (at least) the mandatory keys 'x', 'y', 'xlabel', 'ylabel'
+    representing the plot data.
+    Additional keys: 'mean' (float) and 'Std Dev' (float) representing
+    the mean and standard deviation of the data
+    '''
+    plot_data = {}
+    data = residuals.get_likelihood_values_for(gmpe, imt)
+
+    for res_type in data.keys():
+        lh_vals, median_lh = data[res_type]
+        vals, bins = _get_lh_histogram_data(lh_vals, bin_width=bin_width)
+
+        x = bins[:-1]
+        y = vals
+
+        if as_json:
+            median_lh, x, y = _tojson(median_lh, x, y)
+
+        plot_data[res_type] = \
+            {'x': x, 'y': y, 'median': median_lh,
+             'xlabel': "LH (%s)" % imt, 'ylabel': "Frequency"}
+
+    return plot_data
+
+
+def _get_lh_histogram_data(lh_values, bin_width=0.1):
+    """
+
+    """
+    bins = np.arange(0.0, 1.0 + bin_width, bin_width)
+    vals = np.histogram(lh_values, bins, density=True)[0]
+    return vals.astype(float), bins
+
+
+def residuals_vs_mag(residuals, gmpe, imt, as_json=False):
+    '''Returns the residuals of the given gmpe and imt vs. magnitude
+
+    :param residuals:
+            Residuals as instance of :class: smtk.gmpe_residuals.Residuals
+    :param gmpe: (string) the gmpe/gsim
+    :param imt: (string) the intensity measure type
+    :param as_json: when True, converts all numpy numeric values (scalar
+    and arrays) to their python equivalent. False by default
+
+    :return: a dict mapping each residual type (string, e.g. 'Intra event') to
+    a dict with (at least) the mandatory keys 'x', 'y', 'xlabel', 'ylabel'
+    representing the plot data.
+    Additional keys: 'slope' (float), 'intercept' (float) and 'pvalue' (float)
+    representing the linear regression of the data
+    '''
+    plot_data = {}
+    data = residuals.residuals[gmpe][imt]
+
+    for res_type in data.keys():
+
+        x = _get_magnitudes(residuals, gmpe, imt, res_type)
+        slope, intercept, _, pval, _ = linregress(x, data[res_type])
+        y = data[res_type]
+
+        if as_json:
+            x, y, slope, intercept, pval = \
+                _tojson(x, y, slope, intercept, pval)
+
+        plot_data[res_type] = \
+            {'x': x, 'y': y,
+             'slope': slope, 'intercept': intercept, 'pvalue': pval,
+             'xlabel': "Magnitude", 'ylabel': "Z (%s)" % imt}
+
+    return plot_data
+
+
+def _get_magnitudes(residuals, gmpe, imt, res_type):
+    """
+    Returns an array of magnitudes equal in length to the number of
+    residuals
+    """
+    magnitudes = np.array([])
+    for i, ctxt in enumerate(residuals.contexts):
+        if res_type == "Inter event":
+
+            nval = np.ones(
+                len(residuals.unique_indices[gmpe][imt][i])
+                )
+        else:
+            nval = np.ones(len(ctxt["Distances"].repi))
+
+        magnitudes = np.hstack([magnitudes, ctxt["Rupture"].mag * nval])
+
+    return magnitudes
+
+
+def residuals_vs_vs30(residuals, gmpe, imt, as_json=False):
+    '''Returns the residuals of the given gmpe and imt vs. vs30
+
+    :param residuals:
+            Residuals as instance of :class: smtk.gmpe_residuals.Residuals
+    :param gmpe: (string) the gmpe/gsim
+    :param imt: (string) the intensity measure type
+    :param as_json: when True, converts all numpy numeric values (scalar
+    and arrays) to their python equivalent. False by default
+
+    :return: a dict mapping each residual type (string, e.g. 'Intra event') to
+    a dict with (at least) the mandatory keys 'x', 'y', 'xlabel', 'ylabel'
+    representing the plot data.
+    Additional keys: 'slope' (float), 'intercept' (float) and 'pvalue' (float)
+    representing the linear regression of the data
+    '''
+
+    plot_data = {}
+    data = residuals.residuals[gmpe][imt]
+
+    for res_type in data.keys():
+
+        x = _get_vs30(gmpe, imt, res_type)
+        slope, intercept, _, pval, _ = linregress(x, data[res_type])
+        y = data[res_type]
+
+        if as_json:
+            x, y, slope, intercept, pval = \
+                _tojson(x, y, slope, intercept, pval)
+
+        plot_data[res_type] = \
+            {'x': x, 'y': data[res_type].tolist(),
+             'slope': slope, 'intercept': intercept, 'pvalue': pval,
+             'xlabel': "Vs30 (m/s)", 'ylabel': "Z (%s)" % imt}
+
+    return plot_data
+
+
+def _get_vs30(residuals, gmpe, imt, res_type):
+    """
+
+    """
+    vs30 = np.array([])
+    for i, ctxt in enumerate(residuals.contexts):
+        if res_type == "Inter event":
+            vs30 = np.hstack([vs30, ctxt["Sites"].vs30[
+                residuals.unique_indices[gmpe][imt][i]]])
+        else:
+            vs30 = np.hstack([vs30, ctxt["Sites"].vs30])
+    return vs30
+
+
+def residuals_vs_dist(residuals, gmpe, imt, distance_type="rjb",
+                      as_json=False):
+    '''Returns the residuals of the given gmpe and imt vs. distance
+
+    :param residuals:
+            Residuals as instance of :class: smtk.gmpe_residuals.Residuals
+    :param gmpe: (string) the gmpe/gsim
+    :param imt: (string) the intensity measure type
+    :param as_json: when True, converts all numpy numeric values (scalar
+    and arrays) to their python equivalent. False by default
+
+    :return: a dict mapping each residual type (string, e.g. 'Intra event') to
+    a dict with (at least) the mandatory keys 'x', 'y', 'xlabel', 'ylabel'
+    representing the plot data.
+    Additional keys: 'slope' (float), 'intercept' (float) and 'pvalue' (float)
+    representing the linear regression of the data
+    '''
+    plot_data = {}
+    data = residuals.residuals[gmpe][imt]
+
+    for res_type in data.keys():
+
+        x = _get_distances(gmpe, imt, res_type)
+        slope, intercept, _, pval, _ = linregress(x, data[res_type])
+        y = data[res_type]
+
+        if as_json:
+            x, y, slope, intercept, pval = \
+                _tojson(x, y, slope, intercept, pval)
+
+        plot_data[res_type] = \
+            {'x': x, 'y': data[res_type].tolist(),
+             'slope': slope, 'intercept': intercept, 'pvalue': pval,
+             'xlabel': "%s Distance (km)" % distance_type,
+             'ylabel': "Z (%s)" % imt}
+
+    return plot_data
+
+
+def _get_distances(residuals, gmpe, imt, res_type, distance_type):
+    """
+
+    """
+    distances = np.array([])
+    for i, ctxt in enumerate(residuals.contexts):
+        # Get the distances
+        if res_type == "Inter event":
+            ctxt_dist = getattr(ctxt["Distances"], distance_type)[
+                residuals.unique_indices[gmpe][imt][i]]
+            distances = np.hstack([distances, ctxt_dist])
+        else:
+            distances = np.hstack([
+                distances,
+                getattr(ctxt["Distances"], distance_type)
+                ])
+    return distances
+
+
+def residuals_vs_depth(residuals, gmpe, imt, as_json=False):
+    '''Returns the residuals of the given gmpe and imt vs. depth
+
+    :param residuals:
+            Residuals as instance of :class: smtk.gmpe_residuals.Residuals
+    :param gmpe: (string) the gmpe/gsim
+    :param imt: (string) the intensity measure type
+    :param as_json: when True, converts all numpy numeric values (scalar
+    and arrays) to their python equivalent. False by default
+
+    :return: a dict mapping each residual type (string, e.g. 'Intra event') to
+    a dict with (at least) the mandatory keys 'x', 'y', 'xlabel', 'ylabel'
+    representing the plot data.
+    Additional keys: 'slope' (float), 'intercept' (float) and 'pvalue' (float)
+    representing the linear regression of the data
+    '''
+    plot_data = {}
+    data = residuals.residuals[gmpe][imt]
+
+    for res_type in data.keys():
+
+        x = _get_depths(gmpe, imt, res_type)
+        slope, intercept, _, pval, _ = linregress(x, data[res_type])
+        y = data[res_type]
+
+        if as_json:
+            x, y, slope, intercept, pval = \
+                _tojson(x, y, slope, intercept, pval)
+
+        plot_data[res_type] = \
+            {'x': x, 'y': data[res_type].tolist(),
+             'slope': slope, 'intercept': intercept, 'pvalue': pval,
+             'xlabel': "Hypocentral Depth (km)",
+             'ylabel': "Z (%s)" % imt}
+
+    return plot_data
+
+
+def _get_depths(residuals, gmpe, imt, res_type):
+    """
+    Returns an array of magnitudes equal in length to the number of
+    residuals
+    """
+    depths = np.array([])
+    for i, ctxt in enumerate(residuals.contexts):
+        if res_type == "Inter event":
+            nvals = np.ones(
+                len(residuals.unique_indices[gmpe][imt][i]))
+        else:
+            nvals = np.ones(len(ctxt["Distances"].repi))
+        # TODO This hack needs to be fixed!!!
+        if not ctxt["Rupture"].hypo_depth:
+            depths = np.hstack([depths, 10.0 * nvals])
+        else:
+            depths = np.hstack([depths,
+                                ctxt["Rupture"].hypo_depth * nvals])

--- a/smtk/residuals/residual_plots.py
+++ b/smtk/residuals/residual_plots.py
@@ -62,8 +62,8 @@ def residuals_density_distribution(residuals, gmpe, imt, bin_width=0.5,
 
         vals, bins = _get_histogram_data(data[res_type], bin_width=bin_width)
 
-        mean = statistics[res_type]["mean"]
-        stddev = statistics[res_type]["stddev"]
+        mean = statistics[res_type]["Mean"]
+        stddev = statistics[res_type]["Std Dev"]
         x = bins[:-1]
         y = vals
 
@@ -213,7 +213,7 @@ def residuals_vs_vs30(residuals, gmpe, imt, as_json=False):
 
     for res_type in data.keys():
 
-        x = _get_vs30(gmpe, imt, res_type)
+        x = _get_vs30(residuals, gmpe, imt, res_type)
         slope, intercept, _, pval, _ = linregress(x, data[res_type])
         y = data[res_type]
 
@@ -222,7 +222,7 @@ def residuals_vs_vs30(residuals, gmpe, imt, as_json=False):
                 _tojson(x, y, slope, intercept, pval)
 
         plot_data[res_type] = \
-            {'x': x, 'y': data[res_type].tolist(),
+            {'x': x, 'y': y,
              'slope': slope, 'intercept': intercept, 'pvalue': pval,
              'xlabel': "Vs30 (m/s)", 'ylabel': "Z (%s)" % imt}
 
@@ -265,7 +265,7 @@ def residuals_vs_dist(residuals, gmpe, imt, distance_type="rjb",
 
     for res_type in data.keys():
 
-        x = _get_distances(gmpe, imt, res_type)
+        x = _get_distances(residuals, gmpe, imt, res_type, distance_type)
         slope, intercept, _, pval, _ = linregress(x, data[res_type])
         y = data[res_type]
 
@@ -274,7 +274,7 @@ def residuals_vs_dist(residuals, gmpe, imt, distance_type="rjb",
                 _tojson(x, y, slope, intercept, pval)
 
         plot_data[res_type] = \
-            {'x': x, 'y': data[res_type].tolist(),
+            {'x': x, 'y': y,
              'slope': slope, 'intercept': intercept, 'pvalue': pval,
              'xlabel': "%s Distance (km)" % distance_type,
              'ylabel': "Z (%s)" % imt}
@@ -322,7 +322,7 @@ def residuals_vs_depth(residuals, gmpe, imt, as_json=False):
 
     for res_type in data.keys():
 
-        x = _get_depths(gmpe, imt, res_type)
+        x = _get_depths(residuals, gmpe, imt, res_type)
         slope, intercept, _, pval, _ = linregress(x, data[res_type])
         y = data[res_type]
 
@@ -331,7 +331,7 @@ def residuals_vs_depth(residuals, gmpe, imt, as_json=False):
                 _tojson(x, y, slope, intercept, pval)
 
         plot_data[res_type] = \
-            {'x': x, 'y': data[res_type].tolist(),
+            {'x': x, 'y': y,
              'slope': slope, 'intercept': intercept, 'pvalue': pval,
              'xlabel': "Hypocentral Depth (km)",
              'ylabel': "Z (%s)" % imt}
@@ -357,3 +357,4 @@ def _get_depths(residuals, gmpe, imt, res_type):
         else:
             depths = np.hstack([depths,
                                 ctxt["Rupture"].hypo_depth * nvals])
+    return depths

--- a/smtk/residuals/residual_plotter.py
+++ b/smtk/residuals/residual_plotter.py
@@ -32,7 +32,7 @@ from smtk.residuals.gmpe_residuals import (Residuals,
                                            SingleStationAnalysis)
 
 from smtk.residuals.residual_plots import residuals_density_distribution, \
-    residuals_lh_density_distribution,\
+    likelihood_density_distribution,\
     residuals_vs_mag, residuals_vs_vs30, \
     residuals_vs_dist, residuals_vs_depth
 
@@ -403,8 +403,8 @@ class LikelihoodPlot(ResidualHistogramPlot):
         assert isinstance(residuals, Likelihood)
 
     def get_plot_data(self):
-        return residuals_lh_density_distribution(self.residuals, self.gmpe,
-                                                 self.imt, self.bin_width)
+        return likelihood_density_distribution(self.residuals, self.gmpe,
+                                               self.imt, self.bin_width)
 
 #     def draw(self, ax, res_data, res_type):
 #         x, y = res_data['x'], res_data['y']

--- a/smtk/residuals/residual_plotter.py
+++ b/smtk/residuals/residual_plotter.py
@@ -71,7 +71,7 @@ class BaseResidualPlot(object):
             raise ValueError("No residual data found for GMPE %s" % gmpe)
         if imt not in residuals.imts:
             raise ValueError("No residual data found for IMT %s" % imt)
-        if not residuals.residuals[self.gmpe][self.imt]:
+        if not residuals.residuals[gmpe][imt]:
             raise ValueError("No residuals found for %s (%s)" % (gmpe, imt))
         self.gmpe = gmpe
         self.imt = imt
@@ -250,11 +250,11 @@ class ResidualHistogramPlot(BaseResidualPlot):
         :param bin_width: float denoting the bin width of the histogram.
             defaults to 0.5
         """
-        super(ResidualPlot, self).__init__(residuals, gmpe, imt,
-                                           filename=filename,
-                                           filetype=filetype,
-                                           dpi=dpi, **kwargs)
         self.bin_width = bin_width
+        super(ResidualHistogramPlot, self).__init__(residuals, gmpe, imt,
+                                                    filename=filename,
+                                                    filetype=filetype,
+                                                    dpi=dpi, **kwargs)
 
     def get_subplots_rowcols(self):
         if self.num_plots > 1:
@@ -493,11 +493,11 @@ class ResidualScatterPlot(BaseResidualPlot):
         :param plot_type: string denoting if the plot x axis should be
             logarithmic (provide 'log' in case). Default: '' (no log x axis)
         """
+        self.plot_type = plot_type
         super(ResidualScatterPlot, self).__init__(residuals, gmpe, imt,
                                                   filename=filename,
                                                   filetype=filetype,
                                                   dpi=dpi, **kwargs)
-        self.plot_type = plot_type
 #     def create_linreg(self, res_data, res_type):
 #         x, slope, intercept = \
 #             res_data['x'], res_data['slope'], res_data['intercept']
@@ -623,13 +623,13 @@ class ResidualWithDistance(ResidualScatterPlot):
         :param distance_type: string denoting the distance type to be
             used. Defaults to 'rjb'
         """
+        self.distance_type = distance_type
         super(ResidualWithDistance, self).__init__(residuals, gmpe, imt,
                                                    filename=filename,
                                                    filetype=filetype,
                                                    dpi=dpi,
                                                    plot_type=plot_type,
                                                    **kwargs)
-        self.distance_type = distance_type
 
     def get_plot_data(self):
         return residuals_vs_dist(self.residuals, self.gmpe, self.imt,

--- a/smtk/residuals/residual_plotter.py
+++ b/smtk/residuals/residual_plotter.py
@@ -16,7 +16,6 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
-
 """
 Class to hold GMPE residual plotting functions
 """
@@ -26,47 +25,64 @@ import matplotlib.pyplot as plt
 from copy import deepcopy
 from collections import OrderedDict
 from math import floor, ceil
-from scipy.stats import norm, linregress
+from scipy.stats import norm  # , linregress
 from smtk.sm_utils import _save_image
 from smtk.residuals.gmpe_residuals import (Residuals,
                                            Likelihood,
                                            SingleStationAnalysis)
 
+from smtk.residuals.residual_plots import residuals_density_distribution, \
+    residuals_lh_density_distribution,\
+    residuals_vs_mag, residuals_vs_vs30, \
+    residuals_vs_dist, residuals_vs_depth
 
-class ResidualPlot(object):
+
+class BaseResidualPlot(object):
     """
-    Class to create a simple histrogram of strong ground motion residuals 
+    Abstract-like class to create a Residual plot of strong ground motion
+    residuals
     """
+
+    # class attributes to be passed to matplotlib xlabel, ylabel and title
+    # methods. Allows DRY (don't repet yourself) plots customization:
+    xlabel_styling_kwargs = dict(fontsize=12)
+    ylabel_styling_kwargs = dict(fontsize=12)
+    title_styling_kwargs = dict(fontsize=12)
+
     def __init__(self, residuals, gmpe, imt, filename=None, filetype="png",
-        dpi=300, **kwargs):
+                 dpi=300, **kwargs):
         """
+        Initializes a BaseResidualPlot
+
         :param residuals:
             Residuals as instance of :class: smtk.gmpe_residuals.Residuals
-        :param str gmpe:
-            Choice of GMPE
-        :param str imt:
-            Choice of IMT
+        :param str gmpe: Choice of GMPE
+        :param str imt: Choice of IMT
+        :param kwargs: optional keyword arguments. Supported are:
+            'figure_size' (default: (7,5)), 'show' (default: True)
         """
-        kwargs.setdefault('plot_type', "log")
-        kwargs.setdefault('distance_type', "rjb")
-        kwargs.setdefault("figure_size", (7, 5))
-        kwargs.setdefault("show", True)
+#         kwargs.setdefault('plot_type', "log")
+#         kwargs.setdefault('distance_type', "rjb")
+#         kwargs.setdefault("figure_size", (7, 5))
+#         kwargs.setdefault("show", True)
         self._assertion_check(residuals)
         self.residuals = residuals
-        if not gmpe in residuals.gmpe_list:
+        if gmpe not in residuals.gmpe_list:
             raise ValueError("No residual data found for GMPE %s" % gmpe)
-        if not imt in residuals.imts:
+        if imt not in residuals.imts:
             raise ValueError("No residual data found for IMT %s" % imt)
+        if not residuals.residuals[self.gmpe][self.imt]:
+            raise ValueError("No residuals found for %s (%s)" % (gmpe, imt))
         self.gmpe = gmpe
         self.imt = imt
         self.filename = filename
         self.filetype = filetype
         self.dpi = dpi
         self.num_plots = len(residuals.types[gmpe][imt])
-        self.distance_type = kwargs["distance_type"]
-        self.plot_type = kwargs["plot_type"]
-        self.figure_size = kwargs["figure_size"]
-        self.show = kwargs["show"]
+#         self.distance_type = kwargs["distance_type"]
+#         self.plot_type = kwargs["plot_type"]
+        self.figure_size = kwargs.get("figure_size",  (7, 5))
+        self.show = kwargs.get("show", True)
         self.create_plot()
 
     def _assertion_check(self, residuals):
@@ -75,424 +91,842 @@ class ResidualPlot(object):
         """
         assert isinstance(residuals, Residuals)
 
-    def create_plot(self, bin_width=0.5):
+    def create_plot(self):
         """
-        Creates a histogram plot
+        Creates a residual plot
         """
-        data = self.residuals.residuals[self.gmpe][self.imt]
-        if not data:
-            print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
-            return
-        statistics = self.residuals.get_residual_statistics()
+        data = self.get_plot_data()
+        # statistics = self.residuals.get_residual_statistics()
         fig = plt.figure(figsize=self.figure_size)
         fig.set_tight_layout(True)
+        nrow, ncol = self.get_subplots_rowcols()
+        for tloc, res_type in enumerate(data.keys(), 1):
+            self._residual_plot(plt.subplot(nrow, ncol, tloc), data[res_type],
+                                res_type)
+        _save_image(self.filename, self.filetype, self.dpi)
+        if self.show:
+            plt.show()
+
+    def get_plot_data(self):
+        '''
+        Builds the data to be plotted.
+        This is an abstract-like method which subclasses need to implement.
+
+        :return: a dictionary with keys denoting the residual types
+        of the given GMPE (`self.gmpe`) and IMT (`self.imt`).
+        Each key (residual type) needs then to be mapped to a residual data
+        dict with at least the mandatory keys 'x', 'y' ,'xlabel' and 'ylabel'
+        (See :module:`smtk.residuals.residual_plots` for a list of available
+        functions that return these kind of dict's and should be in principle
+        be called here)
+        '''
+        raise NotImplementedError()
+
+    def get_subplots_rowcols(self):
+        '''
+        Configures the plot layout (subplots grid).
+        This is an abstract-like method which subclasses need to implement.
+
+        :return: the tuple (row, col) denoting the layout of the
+        figure to be displayed. The returned tuple should be consistent with
+        the residual types available for the given GMPE (`self.gmpe`) and
+        IMT (`self.imt`)
+        '''
+        raise NotImplementedError()
+
+    def _residual_plot(self, ax, res_data, res_type):
+        """
+        Plots the reisudal data on the given axis. This method should in
+            principle not be overridden by sub-classes
+        """
+        self.draw(ax, res_data, res_type)
+        ax.set_xlim(*self.get_axis_xlim(res_data, res_type))
+        ax.set_ylim(*self.get_axis_ylim(res_data, res_type))
+        ax.set_xlabel(res_data['xlabel'], **self.xlabel_styling_kwargs)
+        ax.set_ylabel(res_data['ylabel'], **self.ylabel_styling_kwargs)
+        title_string = self.get_axis_title(res_data, res_type)
+        if title_string:
+            ax.set_title(title_string, **self.title_styling_kwargs)
+
+    def draw(self, ax, res_data, res_type):
+        '''
+        Draws the given residual data into the matplotlib `Axes` object `ax`.
+        This is an abstract-like method which subclasses need to implement.
+
+        :param ax: the matplotlib `Axes` object. this method should call
+            the Axes plot method such as, e.g. `ax.plot(...)`,
+            `ax.semilogx(...)` and so on
+        :param res_data: the residual data to be plotted. It's one of
+            the values of the dict returned by `self.get_plot_data`
+            (`res_type` is the corresponding key): it is a dict with
+            at least the mandatory keys 'x', 'y' (both numeric arrays),
+            'xlabel' and 'ylabel' (both strings). Other keys, if present,
+            should be handled by sub-classes implementation, if needed
+        :param res_type: string denoting the residual type such as, e.g.
+            "Inter event". It's one of the keys of the dict returned by
+            `self.get_plot_data` (`res_data` is the corresponding value)
+        '''
+        raise NotImplementedError()
+
+    def get_axis_xlim(self, res_data, res_type):
+        '''
+        Sets the x-axis limit for each `Axes` object (sub-plot).
+        This method can be overridden by subclasses, by default it returns
+        None, None (i.e., automatic axis limit).
+
+        :param res_data: the residual data to be plotted. It's one of
+            the values of the dict returned by `self.get_plot_data`
+            (`res_type` is the corresponding key): it is a dict with
+            at least the mandatory keys 'x', 'y' (both numeric arrays),
+            'xlabel' and 'ylabel' (both strings). Other keys, if present,
+            should be handled by sub-classes implementation, if needed
+        :param res_type: string denoting the residual type such as, e.g.
+            "Inter event". It's one of the keys of the dict returned by
+            `self.get_plot_data` (`res_data` is the corresponding value)
+
+        :return: a numeric tuple denoting the axis minimum and maximum.
+            None's are allowed and delegate matplotlib for calculating the
+            limits
+        '''
+        return None, None
+
+    def get_axis_ylim(self, res_data, res_type):
+        '''
+        Sets the y-axis limit for each plot.
+        This method can be overridden by subclasses, by default it returns
+        None, None (i.e., automatic axis limit).
+
+        :param res_data: the residual data to be plotted. It's one of
+            the values of the dict returned by `self.get_plot_data`
+            (`res_type` is the corresponding key): it is a dict with
+            at least the mandatory keys 'x', 'y' (both numeric arrays),
+            'xlabel' and 'ylabel' (both strings). Other keys, if present,
+            should be handled by sub-classes implementation, if needed
+        :param res_type: string denoting the residual type such as, e.g.
+            "Inter event". It's one of the keys of the dict returned by
+            `self.get_plot_data` (`res_data` is the corresponding value)
+
+        :return: a numeric tuple denoting the axis minimum and maximum.
+            None's are allowed and delegate matplotlib for calculating the
+            limits
+        '''
+        return None, None
+
+    def get_axis_title(self, res_data, res_type):
+        '''
+        Sets the title for each plot.
+        This method can be overridden by subclasses, by default it returns
+        "" (i.e., no title).
+
+        :param res_data: the residual data to be plotted. It's one of
+            the values of the dict returned by `self.get_plot_data`
+            (`res_type` is the corresponding key): it is a dict with
+            at least the mandatory keys 'x', 'y' (both numeric arrays),
+            'xlabel' and 'ylabel' (both strings). Other keys, if present,
+            should be handled by sub-classes implementation, if needed
+        :param res_type: string denoting the residual type such as, e.g.
+            "Inter event". It's one of the keys of the dict returned by
+            `self.get_plot_data` (`res_data` is the corresponding value)
+
+        :return: a string denoting the axis title
+        '''
+        return ""
+
+
+class ResidualHistogramPlot(BaseResidualPlot):
+    """
+    Abstract-like class to create histograms of strong ground motion residuals
+    """
+
+    def __init__(self, residuals, gmpe, imt, filename=None, filetype="png",
+                 dpi=300, bin_width=0.5, **kwargs):
+        """
+        Initializes a ResidualHistogramPlot object. Sub-classes need to
+        implement (at least) the method `get_plot_data`.
+
+        All arguments not listed below are described in
+        `BaseResidualPlot.__init__`.
+
+        :param bin_width: float denoting the bin width of the histogram.
+            defaults to 0.5
+        """
+        super(ResidualPlot, self).__init__(residuals, gmpe, imt,
+                                           filename=filename,
+                                           filetype=filetype,
+                                           dpi=dpi, **kwargs)
+        self.bin_width = bin_width
+
+    def get_subplots_rowcols(self):
         if self.num_plots > 1:
             nrow = 2
             ncol = 2
         else:
             nrow = 1
             ncol = 1
-        tloc = 1
-        for res_type in data.keys():
-            self._density_plot(
-                plt.subplot(nrow, ncol, tloc),
-                data,
-                res_type,
-                statistics,
-                bin_width)
-            tloc += 1
-        _save_image(self.filename, self.filetype, self.dpi)
-        if self.show:
-            plt.show()
-           
-    def _density_plot(self, ax, data, res_type, statistics, bin_width=0.5):
-        """
-        Plots the density distribution on the subplot axis
-        """
-        vals, bins = self.get_histogram_data(data[res_type], bin_width)
-        ax.bar(bins[:-1], vals, width=0.95 * bin_width, color="LightSteelBlue",
-               edgecolor="k")
-        # Get equivalent normal distribution
-        mean = statistics[self.gmpe][self.imt][res_type]["Mean"]
-        stddev = statistics[self.gmpe][self.imt][res_type]["Std Dev"]
-        #print mean, stddev
-        xdata = np.arange(bins[0], bins[-1] + 0.01, 0.01)
+        return nrow, ncol
+
+    def draw(self, ax, res_data, res_type):
+        bin_width = self.bin_width
+        x, y = res_data['x'], res_data['y']
+        ax.bar(x, y, width=0.95 * bin_width,
+               color="LightSteelBlue", edgecolor="k")
+
+
+class ResidualPlot(ResidualHistogramPlot):
+    """
+    Class to create a simple histrogram of strong ground motion residuals
+    """
+#     def __init__(self, residuals, gmpe, imt, filename=None, filetype="png",
+#                  dpi=300, **kwargs):
+#         """
+#         Initializes a ResidualPlot. See `BaseResidualPlot.__init__` for
+#         details on the arguments.
+#         This class supports an additional keyword argument 'bin_width'
+#         (default: 0.5)
+#         """
+#         self.bin_width = kwargs.pop('bin_width', 0.5)
+#         super(ResidualPlot, self).__init__(residuals, gmpe, imt,
+#                                            filename=filename,
+#                                            filetype=filetype,
+#                                            dpi=dpi, **kwargs)
+
+#     def _assertion_check(self, residuals):
+#         """
+#         Checks that residuals is an instance of the residuals class
+#         """
+#         assert isinstance(residuals, Residuals)
+
+#     def create_plot(self, bin_width=0.5):
+#         """
+#         Creates a histogram plot
+#         """
+#         if not self.residuals.residuals[self.gmpe][self.imt]:
+#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
+#             return
+#         data = self.get_plot_data(bin_width)
+#         # statistics = self.residuals.get_residual_statistics()
+#         fig = plt.figure(figsize=self.figure_size)
+#         fig.set_tight_layout(True)
+#         if self.num_plots > 1:
+#             nrow = 2
+#             ncol = 2
+#         else:
+#             nrow = 1
+#             ncol = 1
+#         tloc = 1
+#         for res_type in data.keys():
+#             self._residual_plot(plt.subplot(nrow, ncol, tloc), data, res_type,
+#                                 bin_width)
+#             tloc += 1
+#         _save_image(self.filename, self.filetype, self.dpi)
+#         if self.show:
+#             plt.show()
+
+    def get_plot_data(self):
+        return residuals_density_distribution(self.residuals, self.gmpe,
+                                              self.imt, self.bin_width)
+
+#     def get_subplots_rowcols(self):
+#         if self.num_plots > 1:
+#             nrow = 2
+#             ncol = 2
+#         else:
+#             nrow = 1
+#             ncol = 1
+#         return nrow, ncol
+
+#     def _residual_plot(self, ax, res_data, res_type, bin_width=0.5):
+#         """
+#         Plots the density distribution on the subplot axis
+#         """
+#         self.draw(ax, res_data, res_type, bin_width)
+#         ax.set_xlim(*self.get_axis_xlim(res_data, res_type))
+#         ax.set_ylim(*self.get_axis_ylim(res_data, res_type))
+#         ax.set_xlabel(res_data['xlabel'], fontsize=12)
+#         ax.set_ylabel(res_data['ylabel'], fontsize=12)
+#         title_string = self.get_axis_title(res_data, res_type)
+#         if title_string:
+#             ax.set_title(title_string, fontsize=12)
+
+    def draw(self, ax, res_data, res_type):
+        # draw histogram:
+        super(ResidualPlot, self).draw(ax, res_data, res_type)
+        # draw normal distributions:
+        mean = res_data["mean"]
+        stddev = res_data["stddev"]
+        x = res_data['x']
+        xdata = np.arange(x[0], x[-1] + self.bin_width + 0.01, 0.01)
         ax.plot(xdata, norm.pdf(xdata, mean, stddev), '-',
                 color="LightSlateGrey", linewidth=2.0)
-        ax.plot(xdata, norm.pdf(xdata, 0.0, 1.0), 'k-', linewidth=2.0)
-        ax.set_xlabel("Z (%s)" % self.imt, fontsize=12)
-        ax.set_ylabel("Frequency", fontsize=12)
-        title_string = "%s - %s\n Mean = %7.3f, Std Dev = %7.3f" %(self.gmpe,
-                                                                   res_type,
-                                                                   mean,
-                                                                   stddev)
-        ax.set_title(title_string, fontsize=12)
-        
-    def get_histogram_data(self, data, bin_width=0.5):
-        """
-        Retreives the histogram of the residuals
-        """
-        bins = np.arange(np.floor(np.min(data)),
-                         np.ceil(np.max(data)) + bin_width,
-                         bin_width)
-        vals = np.histogram(data, bins, density=True)[0]
-        return vals.astype(float), bins
-        
+        ax.plot(xdata, norm.pdf(xdata, 0.0, 1.0), '-',
+                color='k', linewidth=2.0)
 
-class LikelihoodPlot(ResidualPlot):
+#     def get_axis_xlim(self, res_data, res_type):
+#         return None, None
+# 
+#     def get_axis_ylim(self, res_data, res_type):
+#         return None, None
+
+    def get_axis_title(self, res_data, res_type):
+        mean, stddev = res_data["mean"], res_data["stddev"]
+        return "%s - %s\n Mean = %7.3f, Std Dev = %7.3f" % (self.gmpe,
+                                                            res_type,
+                                                            mean,
+                                                            stddev)
+
+
+class LikelihoodPlot(ResidualHistogramPlot):
+    """
+    Abstract-like class to create a simple histrogram of strong ground motion
+    likelihood
     """
 
-    """
+    def __init__(self, residuals, gmpe, imt, filename=None, filetype="png",
+                 dpi=300, bin_width=0.1, **kwargs):
+        """
+        Initializes a LikelihoodPlot. Basically calls the superclass
+        `__init__` method with a `bin_width` default value of 0.1 instead of
+        0.5
+        """
+        super(LikelihoodPlot, self).__init__(residuals, gmpe, imt,
+                                             filename=filename,
+                                             filetype=filetype,
+                                             dpi=dpi,
+                                             bin_width=bin_width,
+                                             **kwargs)
 
     def _assertion_check(self, residuals):
         """
-
+            overrides the super-class method by asserting we are dealing
+            with a `Likelihood` class
         """
         assert isinstance(residuals, Likelihood)
 
-    def create_plot(self, bin_width=0.1):
-        """
-        Creates a histogram plot
-        """
-        #data = self.residuals.residuals[self.gmpe][self.imt]
-        lh_vals, statistics = self.residuals.get_likelihood_values()
-        lh_vals = lh_vals[self.gmpe][self.imt]
-        statistics = statistics[self.gmpe][self.imt]
-        fig = plt.figure(figsize=self.figure_size)
-        fig.set_tight_layout(True)
-        if self.num_plots > 1:
-            nrow = 2
-            ncol = 2
-        else:
-            nrow = 1
-            ncol = 1
-        tloc = 1
-        for res_type in lh_vals.keys():
-            self._density_plot(
-                plt.subplot(nrow, ncol, tloc),
-                lh_vals[res_type],
-                res_type,
-                statistics[res_type],
-                bin_width)
-            tloc += 1
-        _save_image(self.filename, self.filetype, self.dpi)
-        if self.show:
-            plt.show()
-        
+    def get_plot_data(self):
+        return residuals_lh_density_distribution(self.residuals, self.gmpe,
+                                                 self.imt, self.bin_width)
 
-    def _density_plot(self, ax, lh_values, res_type, statistics, 
-            bin_width=0.1):
-        """
-        """
-        vals, bins = self.get_histogram_data(lh_values, bin_width)
-        ax.bar(bins[:-1], vals, width=0.95 * bin_width, color="LightSteelBlue",
-               edgecolor="k")
-        # Get equivalent normal distribution
-        median_lh = statistics["Median LH"]
-        ax.set_xlabel("LH (%s)" % self.imt, fontsize=12)
-        ax.set_ylabel("Frequency", fontsize=12)
-        ax.set_xlim(0., 1.0)
-        title_string = "%s - %s\n Median LH = %7.3f" %(self.gmpe,
-                                                       res_type,
-                                                       median_lh)
-        ax.set_title(title_string, fontsize=12)
-    
-    
-    def get_histogram_data(self, lh_values, bin_width=0.1):
-        """
+#     def draw(self, ax, res_data, res_type):
+#         x, y = res_data['x'], res_data['y']
+#         ax.bar(x, y, width=0.95 * self.bin_width,
+#                **self.hist_styling_kwargs)
 
-        """
-        bins = np.arange(0.0, 1.0 + bin_width, bin_width)
-        vals = np.histogram(lh_values, bins, density=True)[0]
-        return vals.astype(float), bins
+    def get_axis_xlim(self, res_data, res_type):
+        return 0., 1.0
+
+    def get_axis_title(self, res_data, res_type):
+        median_lh = res_data["median"]
+        return "%s - %s\n Median LH = %7.3f" % (self.gmpe,
+                                                res_type,
+                                                median_lh)
+
+#     def create_plot(self, bin_width=0.1):
+#         """
+#         Creates a histogram plot
+#         """
+#         #data = self.residuals.residuals[self.gmpe][self.imt]
+#         lh_vals, statistics = self.residuals.get_likelihood_values()
+#         lh_vals = lh_vals[self.gmpe][self.imt]
+#         statistics = statistics[self.gmpe][self.imt]
+#         fig = plt.figure(figsize=self.figure_size)
+#         fig.set_tight_layout(True)
+#         if self.num_plots > 1:
+#             nrow = 2
+#             ncol = 2
+#         else:
+#             nrow = 1
+#             ncol = 1
+#         tloc = 1
+#         for res_type in lh_vals.keys():
+#             self._density_plot(
+#                 plt.subplot(nrow, ncol, tloc),
+#                 lh_vals[res_type],
+#                 res_type,
+#                 statistics[res_type],
+#                 bin_width)
+#             tloc += 1
+#         _save_image(self.filename, self.filetype, self.dpi)
+#         if self.show:
+#             plt.show()
+# 
+#     def _density_plot(self, ax, lh_values, res_type, statistics,
+#                       bin_width=0.1):
+#         """
+#         """
+#         vals, bins = self.get_histogram_data(lh_values, bin_width)
+#         ax.bar(bins[:-1], vals, width=0.95 * bin_width, color="LightSteelBlue",
+#                edgecolor="k")
+#         # Get equivalent normal distribution
+#         median_lh = statistics["Median LH"]
+#         ax.set_xlabel("LH (%s)" % self.imt, fontsize=12)
+#         ax.set_ylabel("Frequency", fontsize=12)
+#         ax.set_xlim(0., 1.0)
+#         title_string = "%s - %s\n Median LH = %7.3f" % (self.gmpe,
+#                                                         res_type,
+#                                                         median_lh)
+#         ax.set_title(title_string, fontsize=12)
+# 
+#     def get_histogram_data(self, lh_values, bin_width=0.1):
+#         """
+# 
+#         """
+#         bins = np.arange(0.0, 1.0 + bin_width, bin_width)
+#         vals = np.histogram(lh_values, bins, density=True)[0]
+#         return vals.astype(float), bins
 
 
-class ResidualWithDistance(ResidualPlot):
+class ResidualScatterPlot(BaseResidualPlot):
+    """
+    Abstract-like class to create scatter plots of strong ground motion
+    residuals
     """
 
-    """
-    def __init__(self, residuals, gmpe, imt, filename=None, filetype="png", 
-         dpi=300, **kwargs):
-         """
-
-         """
-         super(ResidualWithDistance, self).__init__(residuals, gmpe, imt,
-             filename, filetype, dpi, **kwargs)
-
-    def create_plot(self):
+    def __init__(self, residuals, gmpe, imt, filename=None, filetype="png",
+                 dpi=300, plot_type='', **kwargs):
         """
+        Initializes a ResidualScatterPlot object. Sub-classes need to
+        implement (at least) the method `get_plot_data`.
 
+        All arguments not listed below are described in
+        `BaseResidualPlot.__init__`.
+
+        :param plot_type: string denoting if the plot x axis should be
+            logarithmic (provide 'log' in case). Default: '' (no log x axis)
         """
-        data = self.residuals.residuals[self.gmpe][self.imt]
-        if not data:
-            print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
-            return
+        super(ResidualScatterPlot, self).__init__(residuals, gmpe, imt,
+                                                  filename=filename,
+                                                  filetype=filetype,
+                                                  dpi=dpi, **kwargs)
+        self.plot_type = plot_type
+#     def create_linreg(self, res_data, res_type):
+#         x, slope, intercept = \
+#             res_data['x'], res_data['slope'], res_data['intercept']
+#         model_x = np.arange(np.min(x), np.max(x) + 1.0, 1.0)
+#         model_y = intercept + slope * model_x
+#         return model_x, model_y
 
-        fig = plt.figure(figsize=self.figure_size)
-        fig.set_tight_layout(True)
+#     def get_plot_data(self):
+#         raise NotImplementedError()
+
+    def get_subplots_rowcols(self):
         if self.num_plots > 1:
             nrow = 3
             ncol = 1
         else:
             nrow = 1
             ncol = 1
-        tloc = 1
-        for res_type in data.keys():
-            distances = self._get_distances(self.gmpe, self.imt, res_type)
-            self._residual_plot(
-                plt.subplot(nrow, ncol, tloc),
-                distances,
-                data,
-                res_type)
-            tloc += 1
-        _save_image(self.filename, self.filetype, self.dpi)
-        if self.show:
-            plt.show()
+        return nrow, ncol
 
+    def get_axis_xlim(self, res_data, res_type):
+        x = res_data['x']
+        return floor(np.min(x)), ceil(np.max(x))
 
-    def _residual_plot(self, ax, distances, data, res_type):
+    def get_axis_ylim(self, res_data, res_type):
+        y = res_data['y']
+        max_lim = ceil(np.max(np.fabs(y)))
+        return -max_lim, max_lim
+
+    def get_axis_title(self, res_data, res_type):
+        slope, intercept, pval = \
+            res_data['slope'], res_data['intercept'], res_data['pvalue']
+        return "%s - %s\n Slope = %.4e, Intercept = %7.3f p = %.6e " % \
+            (self.gmpe, res_type, slope, intercept, pval)
+
+    def draw(self, ax, res_data, res_type):
         """
 
         """
-        slope, intercept, _, pval, _ = linregress(distances, data[res_type])
-        print("Distance (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
-            intercept, slope, pval))
-        model_x = np.arange(np.min(distances),
-                            np.max(distances) + 1.0,
-                            1.0)
+        x, y = res_data['x'], res_data['y']
+        slope, intercept = res_data['slope'], res_data['intercept']
+        model_x = np.arange(np.min(x), np.max(x) + 1.0, 1.0)
         model_y = intercept + slope * model_x
+        pts_styling_kwargs = dict(markeredgecolor='Gray',
+                                  markerfacecolor='LightSteelBlue')
+        linreg_styling_kwargs = dict(color='r', linewidth=2.0)
         if self.plot_type == "log":
-            ax.semilogx(distances,
-                        data[res_type],
-                        'o',
-                        markeredgecolor='Gray',
-                        markerfacecolor='LightSteelBlue')
-            ax.semilogx(model_x, model_y, 'r-', linewidth=2.0)
-            ax.set_xlim(0.1, 10.0 ** (ceil(np.log10(np.max(distances)))))
+            ax.semilogx(x, y, 'o', **pts_styling_kwargs)
+            ax.semilogx(model_x, model_y, '-', **linreg_styling_kwargs)
         else:
-            ax.plot(distances,
-                    data[res_type],
-                    'o',
-                    markeredgecolor='Gray',
-                    markerfacecolor='LightSteelBlue')
-            ax.plot(model_x, model_y, 'r-', linewidth=2.0)
+            ax.plot(x, y, 'o', **pts_styling_kwargs)
+            ax.plot(model_x, model_y, '-', **linreg_styling_kwargs)
+
+#     def create_plot(self):
+#         """
+#             Creates the plot. `get_plot_data` must have been implemented
+#         """
+#         if not self.residuals.residuals[self.gmpe][self.imt]:
+#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
+#             return
+# 
+#         data = self.get_plot_data()
+# 
+#         fig = plt.figure(figsize=self.figure_size)
+#         fig.set_tight_layout(True)
+#         if self.num_plots > 1:
+#             nrow = 3
+#             ncol = 1
+#         else:
+#             nrow = 1
+#             ncol = 1
+#         tloc = 1
+#         for res_type in data.keys():
+#             self._residual_plot(
+#                 plt.subplot(nrow, ncol, tloc),
+#                 data[res_type],
+#                 res_type)
+#             tloc += 1
+#         _save_image(self.filename, self.filetype, self.dpi)
+#         if self.show:
+#             plt.show()
+
+#     def _residual_plot(self, ax, res_data, res_type):
+# #        model_x, model_y = self.create_linreg(res_data, res_type)
+# #        x, y = res_data['x'], res_data['y']
+#         self.draw(ax, res_data, res_type)
+# #         ax.plot(x, y, **self.axis_plot_kwargs)
+# #         ax.plot(model_x, model_y, 'r-', linewidth=2.0)
+#         ax.set_xlim(*self.get_axis_xlim(res_data, res_type))
+#         ax.set_ylim(*self.get_axis_ylim(res_data, res_type))
+#         ax.grid()
+#         ax.set_xlabel(res_data['xlabel'], fontsize=12)
+#         ax.set_ylabel(res_data['ylabel'], fontsize=12)
+#         title_string = self.get_axis_title(res_data, res_type)
+#         if title_string:
+#             ax.set_title(title_string, fontsize=12)
+
+#     def draw(self, ax, res_data, res_type):
+#         x, y = res_data['x'], res_data['y']
+#         ax.plot(x, y, 'o',
+#                 **self.pts_styling_kwargs)
+#         slope, intercept = res_data['slope'], res_data['intercept']
+#         model_x = np.arange(np.min(x), np.max(x) + 1.0, 1.0)
+#         model_y = intercept + slope * model_x
+#         ax.plot(model_x, model_y, '-',
+#                 **self.linreg_styling_kwargs)
+
+
+class ResidualWithDistance(ResidualScatterPlot):
+    """
+        Class to create a simple scatter plot of strong ground motion
+        residuals (y-axis) versus distance (x-axis)
+    """
+
+    def __init__(self, residuals, gmpe, imt, filename=None, filetype="png",
+                 dpi=300, plot_type='log', distance_type="rjb", **kwargs):
+        """
+        Initializes a ResidualWithDistance object
+
+        All arguments not listed below are described in
+        `ResidualScatterPlot.__init__`. Note that `plot_type` is 'log' by
+        default.
+
+        :param distance_type: string denoting the distance type to be
+            used. Defaults to 'rjb'
+        """
+        super(ResidualWithDistance, self).__init__(residuals, gmpe, imt,
+                                                   filename=filename,
+                                                   filetype=filetype,
+                                                   dpi=dpi,
+                                                   plot_type=plot_type,
+                                                   **kwargs)
+        self.distance_type = distance_type
+
+    def get_plot_data(self):
+        return residuals_vs_dist(self.residuals, self.gmpe, self.imt,
+                                 self.distance_type)
+
+    def get_axis_xlim(self, res_data, res_type):
+        x = res_data['x']
+        if self.plot_type == "log":
+            return 0.1, 10.0 ** (ceil(np.log10(np.max(x))))
+        else:
             if self.distance_type == "rcdpp":
-                ax.set_xlim(np.min(distances), np.max(distances))
+                return np.min(x), np.max(x)
             else:
-                ax.set_xlim(0, np.max(distances))
-        max_lim = ceil(np.max(np.fabs(data[res_type])))
-        ax.set_ylim(-max_lim, max_lim)
-        ax.grid()
-        ax.set_xlabel("%s Distance (km)" % self.distance_type, fontsize=12)
-        ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
-        #title_string = "%s - %s (p = %.5e)" %(self.gmpe, res_type, pval)
-        title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
-                       " p = %.6e " % (self.gmpe, res_type, slope, intercept,
-                                       pval)
-        ax.set_title(title_string, fontsize=12)
+                return 0, np.max(x)
 
-    def _get_distances(self, gmpe, imt, res_type):
-        """
+#     def draw(self, ax, res_data, res_type):
+#         """
+# 
+#         """
+#         x, y = res_data['x'], res_data['y']
+#         slope, intercept = res_data['slope'], res_data['intercept']
+#         model_x = np.arange(np.min(x), np.max(x) + 1.0, 1.0)
+#         model_y = intercept + slope * model_x
+#         if self.plot_type == "log":
+#             ax.semilogx(x, y, 'o', **self.pts_styling_kwargs)
+#             ax.semilogx(model_x, model_y, '-', **self.linreg_styling_kwargs)
+#         else:
+#             ax.plot(x, y, 'o', **self.pts_styling_kwargs)
+#             ax.plot(model_x, model_y, '-', **self.linreg_styling_kwargs)
 
-        """
-        distances = np.array([])
-        for i, ctxt in enumerate(self.residuals.contexts):
-            # Get the distances
-            if res_type == "Inter event":
-                ctxt_dist = getattr(ctxt["Distances"], self.distance_type)[
-                    self.residuals.unique_indices[gmpe][imt][i]]
-                distances = np.hstack([distances, ctxt_dist])
-            else:
-                distances = np.hstack([
-                    distances,
-                    getattr(ctxt["Distances"], self.distance_type)
-                    ])
-        return distances
+#     def create_plot(self):
+#         """
+# 
+#         """
+#         data = self.residuals.residuals[self.gmpe][self.imt]
+#         if not data:
+#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
+#             return
+# 
+#         fig = plt.figure(figsize=self.figure_size)
+#         fig.set_tight_layout(True)
+#         if self.num_plots > 1:
+#             nrow = 3
+#             ncol = 1
+#         else:
+#             nrow = 1
+#             ncol = 1
+#         tloc = 1
+#         for res_type in data.keys():
+#             distances = self._get_distances(self.gmpe, self.imt, res_type)
+#             self._residual_plot(
+#                 plt.subplot(nrow, ncol, tloc),
+#                 distances,
+#                 data,
+#                 res_type)
+#             tloc += 1
+#         _save_image(self.filename, self.filetype, self.dpi)
+#         if self.show:
+#             plt.show()
+# 
+# 
+#     def _residual_plot(self, ax, distances, data, res_type):
+#         """
+# 
+#         """
+#         slope, intercept, _, pval, _ = linregress(distances, data[res_type])
+#         print("Distance (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
+#             intercept, slope, pval))
+#         model_x = np.arange(np.min(distances),
+#                             np.max(distances) + 1.0,
+#                             1.0)
+#         model_y = intercept + slope * model_x
+#         if self.plot_type == "log":
+#             ax.semilogx(distances,
+#                         data[res_type],
+#                         'o',
+#                         markeredgecolor='Gray',
+#                         markerfacecolor='LightSteelBlue')
+#             ax.semilogx(model_x, model_y, 'r-', linewidth=2.0)
+#             ax.set_xlim(0.1, 10.0 ** (ceil(np.log10(np.max(distances)))))
+#         else:
+#             ax.plot(distances,
+#                     data[res_type],
+#                     'o',
+#                     markeredgecolor='Gray',
+#                     markerfacecolor='LightSteelBlue')
+#             ax.plot(model_x, model_y, 'r-', linewidth=2.0)
+#             if self.distance_type == "rcdpp":
+#                 ax.set_xlim(np.min(distances), np.max(distances))
+#             else:
+#                 ax.set_xlim(0, np.max(distances))
+#         max_lim = ceil(np.max(np.fabs(data[res_type])))
+#         ax.set_ylim(-max_lim, max_lim)
+#         ax.grid()
+#         ax.set_xlabel("%s Distance (km)" % self.distance_type, fontsize=12)
+#         ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
+#         #title_string = "%s - %s (p = %.5e)" %(self.gmpe, res_type, pval)
+#         title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
+#                        " p = %.6e " % (self.gmpe, res_type, slope, intercept,
+#                                        pval)
+#         ax.set_title(title_string, fontsize=12)
+
+#     def _get_distances(self, gmpe, imt, res_type):
+#         """
+# 
+#         """
+#         distances = np.array([])
+#         for i, ctxt in enumerate(self.residuals.contexts):
+#             # Get the distances
+#             if res_type == "Inter event":
+#                 ctxt_dist = getattr(ctxt["Distances"], self.distance_type)[
+#                     self.residuals.unique_indices[gmpe][imt][i]]
+#                 distances = np.hstack([distances, ctxt_dist])
+#             else:
+#                 distances = np.hstack([
+#                     distances,
+#                     getattr(ctxt["Distances"], self.distance_type)
+#                     ])
+#         return distances
 
 
-class ResidualWithMagnitude(ResidualPlot):
+class ResidualWithMagnitude(ResidualScatterPlot):
+    """
+        Class to create a simple scatter plot of strong ground motion
+        residuals (y-axis) versus magnitude (x-axis)
     """
 
+    def get_plot_data(self):
+        return residuals_vs_mag(self.residuals, self.gmpe, self.imt)
+
+#     def create_plot(self):
+#         """
+#         Creates the plot
+#         """
+#         data = self.residuals.residuals[self.gmpe][self.imt]
+#         if not data:
+#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
+#             return
+# 
+#         fig = plt.figure(figsize=self.figure_size)
+#         fig.set_tight_layout(True)
+#         if self.num_plots > 1:
+#             nrow = 3
+#             ncol = 1
+#         else:
+#             nrow = 1
+#             ncol = 1
+#         tloc = 1
+#         for res_type in data.keys():
+#             magnitudes = self._get_magnitudes(self.gmpe, self.imt, res_type)
+#             self._residual_plot(
+#                 plt.subplot(nrow, ncol, tloc),
+#                 magnitudes,
+#                 data,
+#                 res_type)
+#             tloc += 1
+#         _save_image(self.filename, self.filetype, self.dpi)
+#         if self.show:
+#             plt.show()
+# 
+# 
+#     def _residual_plot(self, ax, magnitudes, data, res_type):
+#         """
+#         Plots the residuals with magnitude
+#         """
+#         slope, intercept, _, pval, _ = linregress(magnitudes, data[res_type])
+#         print("Magnitude (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
+#             intercept, slope, pval))
+#         model_x = np.arange(np.min(magnitudes),
+#                             np.max(magnitudes) + 1.0,
+#                             1.0)
+#         model_y = intercept + slope * model_x
+#         ax.plot(magnitudes,
+#                 data[res_type],
+#                 'o',
+#                 markeredgecolor='Gray',
+#                 markerfacecolor='LightSteelBlue')
+#         ax.plot(model_x, model_y, 'r-', linewidth=2.0)
+#         ax.set_xlim(floor(np.min(magnitudes)), ceil(np.max(magnitudes)))
+#         max_lim = ceil(np.max(np.fabs(data[res_type])))
+#         ax.set_ylim(-max_lim, max_lim)
+#         ax.grid()
+#         ax.set_xlabel("Magnitude", fontsize=12)
+#         ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
+#         title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
+#                        " p = %.6e " % (self.gmpe, res_type, slope, intercept,
+#                                        pval)
+#         ax.set_title(title_string, fontsize=12)
+
+#     def _get_magnitudes(self, gmpe, imt, res_type):
+#         """
+#         Returns an array of magnitudes equal in length to the number of
+#         residuals
+#         """
+#         magnitudes = np.array([])
+#         for i, ctxt in enumerate(self.residuals.contexts):
+#             if res_type == "Inter event":
+# 
+#                 nval = np.ones(
+#                     len(self.residuals.unique_indices[gmpe][imt][i])
+#                     )
+#             else:
+#                 nval = np.ones(len(ctxt["Distances"].repi))
+# 
+#             magnitudes = np.hstack([magnitudes, ctxt["Rupture"].mag * nval])
+#                 #magnitudes,
+#                 #ctxt["Rupture"].mag * np.ones(len(ctxt["Distances"].repi))])
+#         return magnitudes
+
+
+
+class ResidualWithDepth(ResidualScatterPlot):
     """
-    def __init__(self, residuals, gmpe, imt, filename=None, filetype="png", 
-         dpi=300, **kwargs):
-         """
-
-         """
-         super(ResidualWithMagnitude, self).__init__(residuals, gmpe, imt,
-             filename, filetype, dpi, **kwargs)
-
-    def create_plot(self):
-        """
-        Creates the plot
-        """
-        data = self.residuals.residuals[self.gmpe][self.imt]
-        if not data:
-            print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
-            return
-
-        fig = plt.figure(figsize=self.figure_size)
-        fig.set_tight_layout(True)
-        if self.num_plots > 1:
-            nrow = 3
-            ncol = 1
-        else:
-            nrow = 1
-            ncol = 1
-        tloc = 1
-        for res_type in data.keys():
-            magnitudes = self._get_magnitudes(self.gmpe, self.imt, res_type)
-            self._residual_plot(
-                plt.subplot(nrow, ncol, tloc),
-                magnitudes,
-                data,
-                res_type)
-            tloc += 1
-        _save_image(self.filename, self.filetype, self.dpi)
-        if self.show:
-            plt.show()
-
-
-    def _residual_plot(self, ax, magnitudes, data, res_type):
-        """
-        Plots the residuals with magnitude
-        """
-        slope, intercept, _, pval, _ = linregress(magnitudes, data[res_type])
-        print("Magnitude (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
-            intercept, slope, pval))
-        model_x = np.arange(np.min(magnitudes),
-                            np.max(magnitudes) + 1.0,
-                            1.0)
-        model_y = intercept + slope * model_x
-        ax.plot(magnitudes,
-                data[res_type],
-                'o',
-                markeredgecolor='Gray',
-                markerfacecolor='LightSteelBlue')
-        ax.plot(model_x, model_y, 'r-', linewidth=2.0)
-        ax.set_xlim(floor(np.min(magnitudes)), ceil(np.max(magnitudes)))
-        max_lim = ceil(np.max(np.fabs(data[res_type])))
-        ax.set_ylim(-max_lim, max_lim)
-        ax.grid()
-        ax.set_xlabel("Magnitude", fontsize=12)
-        ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
-        #title_string = "%s - %s (p = %.5e)" %(self.gmpe, res_type, pval)
-        title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
-                       " p = %.6e " % (self.gmpe, res_type, slope, intercept,
-                                       pval)
-        ax.set_title(title_string, fontsize=12)
-
-    def _get_magnitudes(self, gmpe, imt, res_type):
-        """
-        Returns an array of magnitudes equal in length to the number of
-        residuals
-        """
-        magnitudes = np.array([])
-        for i, ctxt in enumerate(self.residuals.contexts):
-            if res_type == "Inter event":
-
-                nval = np.ones(
-                    len(self.residuals.unique_indices[gmpe][imt][i])
-                    )
-            else:
-                nval = np.ones(len(ctxt["Distances"].repi))
-
-            magnitudes = np.hstack([magnitudes, ctxt["Rupture"].mag * nval])
-                #magnitudes,
-                #ctxt["Rupture"].mag * np.ones(len(ctxt["Distances"].repi))])
-        return magnitudes
-    
-
-
-class ResidualWithDepth(ResidualPlot):
+        Class to create a simple scatter plot of strong ground motion
+        residuals (y-axis) versus depth (x-axis)
     """
 
-    """
-    def __init__(self, residuals, gmpe, imt, filename=None, filetype="png", 
-         dpi=300, **kwargs):
-         """
+    def get_plot_data(self):
+        return residuals_vs_depth(self.residuals, self.gmpe, self.imt)
 
-         """
-         super(ResidualWithDepth, self).__init__(residuals, gmpe, imt,
-             filename, filetype, dpi, **kwargs)
+#     def create_plot(self):
+#         """
+#         Creates the plot
+#         """
+#         data = self.residuals.residuals[self.gmpe][self.imt]
+#         if not data:
+#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
+#             return
+# 
+#         fig = plt.figure(figsize=self.figure_size)
+#         fig.set_tight_layout(True)
+#         if self.num_plots > 1:
+#             nrow = 3
+#             ncol = 1
+#         else:
+#             nrow = 1
+#             ncol = 1
+#         tloc = 1
+#         for res_type in data.keys():
+#             depths = self._get_depths(self.gmpe, self.imt, res_type)
+#             self._residual_plot(
+#                 plt.subplot(nrow, ncol, tloc),
+#                 depths,
+#                 data,
+#                 res_type)
+#             tloc += 1
+#         _save_image(self.filename, self.filetype, self.dpi)
+#         if self.show:
+#             plt.show()
+# 
+# 
+#     def _residual_plot(self, ax, depths, data, res_type):
+#         """
+#         Plots the residuals with magnitude
+#         """
+#         slope, intercept, _, pval, _ = linregress(depths, data[res_type])
+#         print("Depth (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
+#             intercept, slope, pval))
+#         model_x = np.arange(np.min(depths),
+#                             np.max(depths) + 1.0,
+#                             1.0)
+#         model_y = intercept + slope * model_x
+#         ax.plot(depths,
+#                 data[res_type],
+#                 'o',
+#                 markeredgecolor='Gray',
+#                 markerfacecolor='LightSteelBlue')
+#         ax.plot(model_x, model_y, 'r-', linewidth=2.0)
+#         ax.set_xlim(floor(np.min(depths)), ceil(np.max(depths)))
+#         max_lim = ceil(np.max(np.fabs(data[res_type])))
+#         ax.set_ylim(-max_lim, max_lim)
+#         ax.grid()
+#         ax.set_xlabel("Hypocentral Depth (km)", fontsize=12)
+#         ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
+#         title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
+#                        " p = %.6e " % (self.gmpe, res_type, slope, intercept,
+#                                        pval)
+#         ax.set_title(title_string, fontsize=12)
 
-    def create_plot(self):
-        """
-        Creates the plot
-        """
-        data = self.residuals.residuals[self.gmpe][self.imt]
-        if not data:
-            print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
-            return
-
-        fig = plt.figure(figsize=self.figure_size)
-        fig.set_tight_layout(True)
-        if self.num_plots > 1:
-            nrow = 3
-            ncol = 1
-        else:
-            nrow = 1
-            ncol = 1
-        tloc = 1
-        for res_type in data.keys():
-            depths = self._get_depths(self.gmpe, self.imt, res_type)
-            self._residual_plot(
-                plt.subplot(nrow, ncol, tloc),
-                depths,
-                data,
-                res_type)
-            tloc += 1
-        _save_image(self.filename, self.filetype, self.dpi)
-        if self.show:
-            plt.show()
-
-
-    def _residual_plot(self, ax, depths, data, res_type):
-        """
-        Plots the residuals with magnitude
-        """
-        slope, intercept, _, pval, _ = linregress(depths, data[res_type])
-        print("Depth (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
-            intercept, slope, pval))
-        model_x = np.arange(np.min(depths),
-                            np.max(depths) + 1.0,
-                            1.0)
-        model_y = intercept + slope * model_x
-        ax.plot(depths,
-                data[res_type],
-                'o',
-                markeredgecolor='Gray',
-                markerfacecolor='LightSteelBlue')
-        ax.plot(model_x, model_y, 'r-', linewidth=2.0)
-        ax.set_xlim(floor(np.min(depths)), ceil(np.max(depths)))
-        max_lim = ceil(np.max(np.fabs(data[res_type])))
-        ax.set_ylim(-max_lim, max_lim)
-        ax.grid()
-        ax.set_xlabel("Hypocentral Depth (km)", fontsize=12)
-        ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
-        title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
-                       " p = %.6e " % (self.gmpe, res_type, slope, intercept,
-                                       pval)
-        ax.set_title(title_string, fontsize=12)
-
-    def _get_depths(self, gmpe, imt, res_type):
-        """
-        Returns an array of magnitudes equal in length to the number of
-        residuals
-        """
-        depths = np.array([])
-        for i, ctxt in enumerate(self.residuals.contexts):
-            if res_type == "Inter event":
-                nvals = np.ones(
-                    len(self.residuals.unique_indices[gmpe][imt][i]))
-            else:
-                nvals = np.ones(len(ctxt["Distances"].repi))
-            # TODO This hack needs to be fixed!!!
-            if not ctxt["Rupture"].hypo_depth:
-                depths = np.hstack([depths, 10.0 * nvals])
-            else:
-                depths = np.hstack([depths,
-                                    ctxt["Rupture"].hypo_depth * nvals])
+#     def _get_depths(self, gmpe, imt, res_type):
+#         """
+#         Returns an array of magnitudes equal in length to the number of
+#         residuals
+#         """
+#         depths = np.array([])
+#         for i, ctxt in enumerate(self.residuals.contexts):
+#             if res_type == "Inter event":
+#                 nvals = np.ones(
+#                     len(self.residuals.unique_indices[gmpe][imt][i]))
+#             else:
+#                 nvals = np.ones(len(ctxt["Distances"].repi))
+#             # TODO This hack needs to be fixed!!!
+#             if not ctxt["Rupture"].hypo_depth:
+#                 depths = np.hstack([depths, 10.0 * nvals])
+#             else:
+#                 depths = np.hstack([depths,
+#                                     ctxt["Rupture"].hypo_depth * nvals])
 #                    depths, 
 #                    10.0 * np.ones(len(ctxt["Distances"].repi))])
 #            else:
@@ -500,107 +934,98 @@ class ResidualWithDepth(ResidualPlot):
 #                    depths,
 #                    ctxt["Rupture"].hypo_depth *
 #                    np.ones(len(ctxt["Distances"].repi))])
-        return depths
+#        return depths
 
 
-
-class ResidualWithVs30(ResidualPlot):
+class ResidualWithVs30(ResidualScatterPlot):
     """
-
+        Class to create a simple scatter plot of strong ground motion
+        residuals (y-axis) versus Vs30 (x-axis)
     """
-    def __init__(self, residuals, gmpe, imt, filename=None, filetype="png", 
-         dpi=300, **kwargs):
-         """
+    def get_plot_data(self):
+        return residuals_vs_vs30(self.residuals, self.gmpe, self.imt)
 
-         """
-         super(ResidualWithVs30, self).__init__(residuals, gmpe, imt,
-             filename, filetype, dpi, **kwargs)
+    def get_axis_xlim(self, res_data, res_type):
+        x = res_data['x']
+        return 0.1, np.max(x)
 
-    def create_plot(self):
-        """
+#     def create_plot(self):
+#         """
+# 
+#         """
+#         data = self.residuals.residuals[self.gmpe][self.imt]
+#         if not data:
+#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
+#             return
+# 
+#         fig = plt.figure(figsize=self.figure_size)
+#         fig.set_tight_layout(True)
+#         if self.num_plots > 1:
+#             nrow = 3
+#             ncol = 1
+#         else:
+#             nrow = 1
+#             ncol = 1
+#         tloc = 1
+#         for res_type in data.keys():
+#             vs30 = self._get_vs30(self.gmpe, self.imt, res_type)
+#             self._residual_plot(
+#                 plt.subplot(nrow, ncol, tloc),
+#                 vs30,
+#                 data,
+#                 res_type)
+#             tloc += 1
+#         _save_image(self.filename, self.filetype, self.dpi)
+#         if self.show:
+#             plt.show()
+# 
+# 
+#     def _residual_plot(self, ax, vs30, data, res_type):
+#         """
+# 
+#         """
+#         slope, intercept, _, pval, _ = linregress(vs30, data[res_type])
+#         print("Site (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
+#             intercept, slope, pval))
+#         model_x = np.arange(np.min(vs30),
+#                             np.max(vs30) + 1.0,
+#                             1.0)
+#         model_y = intercept + slope * model_x
+#         ax.plot(vs30,
+#                 data[res_type],
+#                 'o',
+#                 markeredgecolor='Gray',
+#                 markerfacecolor='LightSteelBlue')
+#         ax.plot(model_x, model_y, 'r-', linewidth=2.0)
+#         ax.set_xlim(0.1, np.max(vs30))
+#         max_lim = ceil(np.max(np.fabs(data[res_type])))
+#         ax.set_ylim(-max_lim, max_lim)
+#         ax.grid()
+#         ax.set_xlabel("Vs30 (m/s)", fontsize=12)
+#         ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
+#         title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
+#                        " p = %.6e " % (self.gmpe, res_type, slope, intercept,
+#                                        pval)
+#         ax.set_title(title_string, fontsize=12)
 
-        """
-        data = self.residuals.residuals[self.gmpe][self.imt]
-        if not data:
-            print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
-            return
-
-        fig = plt.figure(figsize=self.figure_size)
-        fig.set_tight_layout(True)
-        if self.num_plots > 1:
-            nrow = 3
-            ncol = 1
-        else:
-            nrow = 1
-            ncol = 1
-        tloc = 1
-        for res_type in data.keys():
-            vs30 = self._get_vs30(self.gmpe, self.imt, res_type)
-            self._residual_plot(
-                plt.subplot(nrow, ncol, tloc),
-                vs30,
-                data,
-                res_type)
-            tloc += 1
-        _save_image(self.filename, self.filetype, self.dpi)
-        if self.show:
-            plt.show()
-
-
-    def _residual_plot(self, ax, vs30, data, res_type):
-        """
-
-        """
-        slope, intercept, _, pval, _ = linregress(vs30, data[res_type])
-        print("Site (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
-            intercept, slope, pval))
-        model_x = np.arange(np.min(vs30),
-                            np.max(vs30) + 1.0,
-                            1.0)
-        model_y = intercept + slope * model_x
-        ax.plot(vs30,
-                data[res_type],
-                'o',
-                markeredgecolor='Gray',
-                markerfacecolor='LightSteelBlue')
-        ax.plot(model_x, model_y, 'r-', linewidth=2.0)
-        ax.set_xlim(0.1, np.max(vs30))
-        max_lim = ceil(np.max(np.fabs(data[res_type])))
-        ax.set_ylim(-max_lim, max_lim)
-        ax.grid()
-        ax.set_xlabel("Vs30 (m/s)", fontsize=12)
-        ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
-        title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
-                       " p = %.6e " % (self.gmpe, res_type, slope, intercept,
-                                       pval)
-        ax.set_title(title_string, fontsize=12)
-
-    def _get_vs30(self, gmpe, imt, res_type):
-        """
-
-        """
-        vs30 = np.array([])
-        for i, ctxt in enumerate(self.residuals.contexts):
-            if res_type == "Inter event":
-                vs30 = np.hstack([vs30, ctxt["Sites"].vs30[
-                    self.residuals.unique_indices[gmpe][imt][i]]])
-            else:
-                vs30 = np.hstack([vs30, ctxt["Sites"].vs30])
-        return vs30
+#     def _get_vs30(self, gmpe, imt, res_type):
+#         """
+# 
+#         """
+#         vs30 = np.array([])
+#         for i, ctxt in enumerate(self.residuals.contexts):
+#             if res_type == "Inter event":
+#                 vs30 = np.hstack([vs30, ctxt["Sites"].vs30[
+#                     self.residuals.unique_indices[gmpe][imt][i]]])
+#             else:
+#                 vs30 = np.hstack([vs30, ctxt["Sites"].vs30])
+#         return vs30
 
 
 class ResidualWithSite(ResidualPlot):
     """
     Class uses Single-Station residuals to plot residual for specific sites
     """
-    def __init__(self, residuals, gmpe, imt, filename=None, filetype="png", 
-         dpi=300, **kwargs):
-         """
-
-         """
-         super(ResidualWithSite, self).__init__(residuals, gmpe, imt,
-             filename, filetype, dpi, **kwargs)
-    
     def _assertion_check(self, residuals):
         """
         Checks that residuals is en instance of the residuals class
@@ -693,18 +1118,11 @@ class ResidualWithSite(ResidualPlot):
                 np.ones_like(data[site_id]["Intra event"])
         return data
 
+
 class IntraEventResidualWithSite(ResidualPlot):
     """
 
     """
-    def __init__(self, residuals, gmpe, imt, filename=None, filetype="png", 
-         dpi=300, **kwargs):
-         """
-
-         """
-         super(IntraEventResidualWithSite, self).__init__(residuals, gmpe, imt,
-             filename, filetype, dpi, **kwargs)
-    
     def _assertion_check(self, residuals):
         """
         Checks that residuals is an instance of the residuals class
@@ -785,13 +1203,13 @@ class IntraEventResidualWithSite(ResidualPlot):
                 markerfacecolor='LightSteelBlue',
                 markersize=8,
                 zorder=-32)
-        ax.plot(xmean, 
+        ax.plot(xmean,
                 (phi_s2ss["Mean"] - phi_s2ss["StdDev"]) * np.ones(len(xmean)),
                 "k--", linewidth=1.5)
-        ax.plot(xmean, 
+        ax.plot(xmean,
                 (phi_s2ss["Mean"] + phi_s2ss["StdDev"]) * np.ones(len(xmean)),
                 "k--", linewidth=1.5)
-        ax.plot(xmean, 
+        ax.plot(xmean,
                 (phi_s2ss["Mean"]) * np.ones(len(xmean)),
                 "k-", linewidth=2)
         ax.set_xlim(0, len(self.residuals.site_ids))

--- a/smtk/residuals/residual_plotter.py
+++ b/smtk/residuals/residual_plotter.py
@@ -32,9 +32,9 @@ from smtk.residuals.gmpe_residuals import (Residuals,
                                            SingleStationAnalysis)
 
 from smtk.residuals.residual_plots import residuals_density_distribution, \
-    likelihood_density_distribution,\
-    residuals_vs_mag, residuals_vs_vs30, \
-    residuals_vs_dist, residuals_vs_depth
+    likelihood,\
+    residuals_with_magnitude, residuals_with_vs30, \
+    residuals_with_distance, residuals_with_depth
 
 
 class BaseResidualPlot(object):
@@ -61,10 +61,6 @@ class BaseResidualPlot(object):
         :param kwargs: optional keyword arguments. Supported are:
             'figure_size' (default: (7,5)), 'show' (default: True)
         """
-#         kwargs.setdefault('plot_type', "log")
-#         kwargs.setdefault('distance_type', "rjb")
-#         kwargs.setdefault("figure_size", (7, 5))
-#         kwargs.setdefault("show", True)
         self._assertion_check(residuals)
         self.residuals = residuals
         if gmpe not in residuals.gmpe_list:
@@ -79,8 +75,6 @@ class BaseResidualPlot(object):
         self.filetype = filetype
         self.dpi = dpi
         self.num_plots = len(residuals.types[gmpe][imt])
-#         self.distance_type = kwargs["distance_type"]
-#         self.plot_type = kwargs["plot_type"]
         self.figure_size = kwargs.get("figure_size",  (7, 5))
         self.show = kwargs.get("show", True)
         self.create_plot()
@@ -276,77 +270,10 @@ class ResidualPlot(ResidualHistogramPlot):
     """
     Class to create a simple histrogram of strong ground motion residuals
     """
-#     def __init__(self, residuals, gmpe, imt, filename=None, filetype="png",
-#                  dpi=300, **kwargs):
-#         """
-#         Initializes a ResidualPlot. See `BaseResidualPlot.__init__` for
-#         details on the arguments.
-#         This class supports an additional keyword argument 'bin_width'
-#         (default: 0.5)
-#         """
-#         self.bin_width = kwargs.pop('bin_width', 0.5)
-#         super(ResidualPlot, self).__init__(residuals, gmpe, imt,
-#                                            filename=filename,
-#                                            filetype=filetype,
-#                                            dpi=dpi, **kwargs)
-
-#     def _assertion_check(self, residuals):
-#         """
-#         Checks that residuals is an instance of the residuals class
-#         """
-#         assert isinstance(residuals, Residuals)
-
-#     def create_plot(self, bin_width=0.5):
-#         """
-#         Creates a histogram plot
-#         """
-#         if not self.residuals.residuals[self.gmpe][self.imt]:
-#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
-#             return
-#         data = self.get_plot_data(bin_width)
-#         # statistics = self.residuals.get_residual_statistics()
-#         fig = plt.figure(figsize=self.figure_size)
-#         fig.set_tight_layout(True)
-#         if self.num_plots > 1:
-#             nrow = 2
-#             ncol = 2
-#         else:
-#             nrow = 1
-#             ncol = 1
-#         tloc = 1
-#         for res_type in data.keys():
-#             self._residual_plot(plt.subplot(nrow, ncol, tloc), data, res_type,
-#                                 bin_width)
-#             tloc += 1
-#         _save_image(self.filename, self.filetype, self.dpi)
-#         if self.show:
-#             plt.show()
 
     def get_plot_data(self):
         return residuals_density_distribution(self.residuals, self.gmpe,
                                               self.imt, self.bin_width)
-
-#     def get_subplots_rowcols(self):
-#         if self.num_plots > 1:
-#             nrow = 2
-#             ncol = 2
-#         else:
-#             nrow = 1
-#             ncol = 1
-#         return nrow, ncol
-
-#     def _residual_plot(self, ax, res_data, res_type, bin_width=0.5):
-#         """
-#         Plots the density distribution on the subplot axis
-#         """
-#         self.draw(ax, res_data, res_type, bin_width)
-#         ax.set_xlim(*self.get_axis_xlim(res_data, res_type))
-#         ax.set_ylim(*self.get_axis_ylim(res_data, res_type))
-#         ax.set_xlabel(res_data['xlabel'], fontsize=12)
-#         ax.set_ylabel(res_data['ylabel'], fontsize=12)
-#         title_string = self.get_axis_title(res_data, res_type)
-#         if title_string:
-#             ax.set_title(title_string, fontsize=12)
 
     def draw(self, ax, res_data, res_type):
         # draw histogram:
@@ -360,12 +287,6 @@ class ResidualPlot(ResidualHistogramPlot):
                 color="LightSlateGrey", linewidth=2.0)
         ax.plot(xdata, norm.pdf(xdata, 0.0, 1.0), '-',
                 color='k', linewidth=2.0)
-
-#     def get_axis_xlim(self, res_data, res_type):
-#         return None, None
-# 
-#     def get_axis_ylim(self, res_data, res_type):
-#         return None, None
 
     def get_axis_title(self, res_data, res_type):
         mean, stddev = res_data["mean"], res_data["stddev"]
@@ -403,13 +324,7 @@ class LikelihoodPlot(ResidualHistogramPlot):
         assert isinstance(residuals, Likelihood)
 
     def get_plot_data(self):
-        return likelihood_density_distribution(self.residuals, self.gmpe,
-                                               self.imt, self.bin_width)
-
-#     def draw(self, ax, res_data, res_type):
-#         x, y = res_data['x'], res_data['y']
-#         ax.bar(x, y, width=0.95 * self.bin_width,
-#                **self.hist_styling_kwargs)
+        return likelihood(self.residuals, self.gmpe, self.imt, self.bin_width)
 
     def get_axis_xlim(self, res_data, res_type):
         return 0., 1.0
@@ -419,60 +334,6 @@ class LikelihoodPlot(ResidualHistogramPlot):
         return "%s - %s\n Median LH = %7.3f" % (self.gmpe,
                                                 res_type,
                                                 median_lh)
-
-#     def create_plot(self, bin_width=0.1):
-#         """
-#         Creates a histogram plot
-#         """
-#         #data = self.residuals.residuals[self.gmpe][self.imt]
-#         lh_vals, statistics = self.residuals.get_likelihood_values()
-#         lh_vals = lh_vals[self.gmpe][self.imt]
-#         statistics = statistics[self.gmpe][self.imt]
-#         fig = plt.figure(figsize=self.figure_size)
-#         fig.set_tight_layout(True)
-#         if self.num_plots > 1:
-#             nrow = 2
-#             ncol = 2
-#         else:
-#             nrow = 1
-#             ncol = 1
-#         tloc = 1
-#         for res_type in lh_vals.keys():
-#             self._density_plot(
-#                 plt.subplot(nrow, ncol, tloc),
-#                 lh_vals[res_type],
-#                 res_type,
-#                 statistics[res_type],
-#                 bin_width)
-#             tloc += 1
-#         _save_image(self.filename, self.filetype, self.dpi)
-#         if self.show:
-#             plt.show()
-# 
-#     def _density_plot(self, ax, lh_values, res_type, statistics,
-#                       bin_width=0.1):
-#         """
-#         """
-#         vals, bins = self.get_histogram_data(lh_values, bin_width)
-#         ax.bar(bins[:-1], vals, width=0.95 * bin_width, color="LightSteelBlue",
-#                edgecolor="k")
-#         # Get equivalent normal distribution
-#         median_lh = statistics["Median LH"]
-#         ax.set_xlabel("LH (%s)" % self.imt, fontsize=12)
-#         ax.set_ylabel("Frequency", fontsize=12)
-#         ax.set_xlim(0., 1.0)
-#         title_string = "%s - %s\n Median LH = %7.3f" % (self.gmpe,
-#                                                         res_type,
-#                                                         median_lh)
-#         ax.set_title(title_string, fontsize=12)
-# 
-#     def get_histogram_data(self, lh_values, bin_width=0.1):
-#         """
-# 
-#         """
-#         bins = np.arange(0.0, 1.0 + bin_width, bin_width)
-#         vals = np.histogram(lh_values, bins, density=True)[0]
-#         return vals.astype(float), bins
 
 
 class ResidualScatterPlot(BaseResidualPlot):
@@ -498,15 +359,6 @@ class ResidualScatterPlot(BaseResidualPlot):
                                                   filename=filename,
                                                   filetype=filetype,
                                                   dpi=dpi, **kwargs)
-#     def create_linreg(self, res_data, res_type):
-#         x, slope, intercept = \
-#             res_data['x'], res_data['slope'], res_data['intercept']
-#         model_x = np.arange(np.min(x), np.max(x) + 1.0, 1.0)
-#         model_y = intercept + slope * model_x
-#         return model_x, model_y
-
-#     def get_plot_data(self):
-#         raise NotImplementedError()
 
     def get_subplots_rowcols(self):
         if self.num_plots > 1:
@@ -533,9 +385,6 @@ class ResidualScatterPlot(BaseResidualPlot):
             (self.gmpe, res_type, slope, intercept, pval)
 
     def draw(self, ax, res_data, res_type):
-        """
-
-        """
         x, y = res_data['x'], res_data['y']
         slope, intercept = res_data['slope'], res_data['intercept']
         model_x = np.arange(np.min(x), np.max(x) + 1.0, 1.0)
@@ -549,60 +398,6 @@ class ResidualScatterPlot(BaseResidualPlot):
         else:
             ax.plot(x, y, 'o', **pts_styling_kwargs)
             ax.plot(model_x, model_y, '-', **linreg_styling_kwargs)
-
-#     def create_plot(self):
-#         """
-#             Creates the plot. `get_plot_data` must have been implemented
-#         """
-#         if not self.residuals.residuals[self.gmpe][self.imt]:
-#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
-#             return
-# 
-#         data = self.get_plot_data()
-# 
-#         fig = plt.figure(figsize=self.figure_size)
-#         fig.set_tight_layout(True)
-#         if self.num_plots > 1:
-#             nrow = 3
-#             ncol = 1
-#         else:
-#             nrow = 1
-#             ncol = 1
-#         tloc = 1
-#         for res_type in data.keys():
-#             self._residual_plot(
-#                 plt.subplot(nrow, ncol, tloc),
-#                 data[res_type],
-#                 res_type)
-#             tloc += 1
-#         _save_image(self.filename, self.filetype, self.dpi)
-#         if self.show:
-#             plt.show()
-
-#     def _residual_plot(self, ax, res_data, res_type):
-# #        model_x, model_y = self.create_linreg(res_data, res_type)
-# #        x, y = res_data['x'], res_data['y']
-#         self.draw(ax, res_data, res_type)
-# #         ax.plot(x, y, **self.axis_plot_kwargs)
-# #         ax.plot(model_x, model_y, 'r-', linewidth=2.0)
-#         ax.set_xlim(*self.get_axis_xlim(res_data, res_type))
-#         ax.set_ylim(*self.get_axis_ylim(res_data, res_type))
-#         ax.grid()
-#         ax.set_xlabel(res_data['xlabel'], fontsize=12)
-#         ax.set_ylabel(res_data['ylabel'], fontsize=12)
-#         title_string = self.get_axis_title(res_data, res_type)
-#         if title_string:
-#             ax.set_title(title_string, fontsize=12)
-
-#     def draw(self, ax, res_data, res_type):
-#         x, y = res_data['x'], res_data['y']
-#         ax.plot(x, y, 'o',
-#                 **self.pts_styling_kwargs)
-#         slope, intercept = res_data['slope'], res_data['intercept']
-#         model_x = np.arange(np.min(x), np.max(x) + 1.0, 1.0)
-#         model_y = intercept + slope * model_x
-#         ax.plot(model_x, model_y, '-',
-#                 **self.linreg_styling_kwargs)
 
 
 class ResidualWithDistance(ResidualScatterPlot):
@@ -632,8 +427,8 @@ class ResidualWithDistance(ResidualScatterPlot):
                                                    **kwargs)
 
     def get_plot_data(self):
-        return residuals_vs_dist(self.residuals, self.gmpe, self.imt,
-                                 self.distance_type)
+        return residuals_with_distance(self.residuals, self.gmpe, self.imt,
+                                       self.distance_type)
 
     def get_axis_xlim(self, res_data, res_type):
         x = res_data['x']
@@ -645,111 +440,6 @@ class ResidualWithDistance(ResidualScatterPlot):
             else:
                 return 0, np.max(x)
 
-#     def draw(self, ax, res_data, res_type):
-#         """
-# 
-#         """
-#         x, y = res_data['x'], res_data['y']
-#         slope, intercept = res_data['slope'], res_data['intercept']
-#         model_x = np.arange(np.min(x), np.max(x) + 1.0, 1.0)
-#         model_y = intercept + slope * model_x
-#         if self.plot_type == "log":
-#             ax.semilogx(x, y, 'o', **self.pts_styling_kwargs)
-#             ax.semilogx(model_x, model_y, '-', **self.linreg_styling_kwargs)
-#         else:
-#             ax.plot(x, y, 'o', **self.pts_styling_kwargs)
-#             ax.plot(model_x, model_y, '-', **self.linreg_styling_kwargs)
-
-#     def create_plot(self):
-#         """
-# 
-#         """
-#         data = self.residuals.residuals[self.gmpe][self.imt]
-#         if not data:
-#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
-#             return
-# 
-#         fig = plt.figure(figsize=self.figure_size)
-#         fig.set_tight_layout(True)
-#         if self.num_plots > 1:
-#             nrow = 3
-#             ncol = 1
-#         else:
-#             nrow = 1
-#             ncol = 1
-#         tloc = 1
-#         for res_type in data.keys():
-#             distances = self._get_distances(self.gmpe, self.imt, res_type)
-#             self._residual_plot(
-#                 plt.subplot(nrow, ncol, tloc),
-#                 distances,
-#                 data,
-#                 res_type)
-#             tloc += 1
-#         _save_image(self.filename, self.filetype, self.dpi)
-#         if self.show:
-#             plt.show()
-# 
-# 
-#     def _residual_plot(self, ax, distances, data, res_type):
-#         """
-# 
-#         """
-#         slope, intercept, _, pval, _ = linregress(distances, data[res_type])
-#         print("Distance (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
-#             intercept, slope, pval))
-#         model_x = np.arange(np.min(distances),
-#                             np.max(distances) + 1.0,
-#                             1.0)
-#         model_y = intercept + slope * model_x
-#         if self.plot_type == "log":
-#             ax.semilogx(distances,
-#                         data[res_type],
-#                         'o',
-#                         markeredgecolor='Gray',
-#                         markerfacecolor='LightSteelBlue')
-#             ax.semilogx(model_x, model_y, 'r-', linewidth=2.0)
-#             ax.set_xlim(0.1, 10.0 ** (ceil(np.log10(np.max(distances)))))
-#         else:
-#             ax.plot(distances,
-#                     data[res_type],
-#                     'o',
-#                     markeredgecolor='Gray',
-#                     markerfacecolor='LightSteelBlue')
-#             ax.plot(model_x, model_y, 'r-', linewidth=2.0)
-#             if self.distance_type == "rcdpp":
-#                 ax.set_xlim(np.min(distances), np.max(distances))
-#             else:
-#                 ax.set_xlim(0, np.max(distances))
-#         max_lim = ceil(np.max(np.fabs(data[res_type])))
-#         ax.set_ylim(-max_lim, max_lim)
-#         ax.grid()
-#         ax.set_xlabel("%s Distance (km)" % self.distance_type, fontsize=12)
-#         ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
-#         #title_string = "%s - %s (p = %.5e)" %(self.gmpe, res_type, pval)
-#         title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
-#                        " p = %.6e " % (self.gmpe, res_type, slope, intercept,
-#                                        pval)
-#         ax.set_title(title_string, fontsize=12)
-
-#     def _get_distances(self, gmpe, imt, res_type):
-#         """
-# 
-#         """
-#         distances = np.array([])
-#         for i, ctxt in enumerate(self.residuals.contexts):
-#             # Get the distances
-#             if res_type == "Inter event":
-#                 ctxt_dist = getattr(ctxt["Distances"], self.distance_type)[
-#                     self.residuals.unique_indices[gmpe][imt][i]]
-#                 distances = np.hstack([distances, ctxt_dist])
-#             else:
-#                 distances = np.hstack([
-#                     distances,
-#                     getattr(ctxt["Distances"], self.distance_type)
-#                     ])
-#         return distances
-
 
 class ResidualWithMagnitude(ResidualScatterPlot):
     """
@@ -758,87 +448,7 @@ class ResidualWithMagnitude(ResidualScatterPlot):
     """
 
     def get_plot_data(self):
-        return residuals_vs_mag(self.residuals, self.gmpe, self.imt)
-
-#     def create_plot(self):
-#         """
-#         Creates the plot
-#         """
-#         data = self.residuals.residuals[self.gmpe][self.imt]
-#         if not data:
-#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
-#             return
-# 
-#         fig = plt.figure(figsize=self.figure_size)
-#         fig.set_tight_layout(True)
-#         if self.num_plots > 1:
-#             nrow = 3
-#             ncol = 1
-#         else:
-#             nrow = 1
-#             ncol = 1
-#         tloc = 1
-#         for res_type in data.keys():
-#             magnitudes = self._get_magnitudes(self.gmpe, self.imt, res_type)
-#             self._residual_plot(
-#                 plt.subplot(nrow, ncol, tloc),
-#                 magnitudes,
-#                 data,
-#                 res_type)
-#             tloc += 1
-#         _save_image(self.filename, self.filetype, self.dpi)
-#         if self.show:
-#             plt.show()
-# 
-# 
-#     def _residual_plot(self, ax, magnitudes, data, res_type):
-#         """
-#         Plots the residuals with magnitude
-#         """
-#         slope, intercept, _, pval, _ = linregress(magnitudes, data[res_type])
-#         print("Magnitude (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
-#             intercept, slope, pval))
-#         model_x = np.arange(np.min(magnitudes),
-#                             np.max(magnitudes) + 1.0,
-#                             1.0)
-#         model_y = intercept + slope * model_x
-#         ax.plot(magnitudes,
-#                 data[res_type],
-#                 'o',
-#                 markeredgecolor='Gray',
-#                 markerfacecolor='LightSteelBlue')
-#         ax.plot(model_x, model_y, 'r-', linewidth=2.0)
-#         ax.set_xlim(floor(np.min(magnitudes)), ceil(np.max(magnitudes)))
-#         max_lim = ceil(np.max(np.fabs(data[res_type])))
-#         ax.set_ylim(-max_lim, max_lim)
-#         ax.grid()
-#         ax.set_xlabel("Magnitude", fontsize=12)
-#         ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
-#         title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
-#                        " p = %.6e " % (self.gmpe, res_type, slope, intercept,
-#                                        pval)
-#         ax.set_title(title_string, fontsize=12)
-
-#     def _get_magnitudes(self, gmpe, imt, res_type):
-#         """
-#         Returns an array of magnitudes equal in length to the number of
-#         residuals
-#         """
-#         magnitudes = np.array([])
-#         for i, ctxt in enumerate(self.residuals.contexts):
-#             if res_type == "Inter event":
-# 
-#                 nval = np.ones(
-#                     len(self.residuals.unique_indices[gmpe][imt][i])
-#                     )
-#             else:
-#                 nval = np.ones(len(ctxt["Distances"].repi))
-# 
-#             magnitudes = np.hstack([magnitudes, ctxt["Rupture"].mag * nval])
-#                 #magnitudes,
-#                 #ctxt["Rupture"].mag * np.ones(len(ctxt["Distances"].repi))])
-#         return magnitudes
-
+        return residuals_with_magnitude(self.residuals, self.gmpe, self.imt)
 
 
 class ResidualWithDepth(ResidualScatterPlot):
@@ -848,93 +458,7 @@ class ResidualWithDepth(ResidualScatterPlot):
     """
 
     def get_plot_data(self):
-        return residuals_vs_depth(self.residuals, self.gmpe, self.imt)
-
-#     def create_plot(self):
-#         """
-#         Creates the plot
-#         """
-#         data = self.residuals.residuals[self.gmpe][self.imt]
-#         if not data:
-#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
-#             return
-# 
-#         fig = plt.figure(figsize=self.figure_size)
-#         fig.set_tight_layout(True)
-#         if self.num_plots > 1:
-#             nrow = 3
-#             ncol = 1
-#         else:
-#             nrow = 1
-#             ncol = 1
-#         tloc = 1
-#         for res_type in data.keys():
-#             depths = self._get_depths(self.gmpe, self.imt, res_type)
-#             self._residual_plot(
-#                 plt.subplot(nrow, ncol, tloc),
-#                 depths,
-#                 data,
-#                 res_type)
-#             tloc += 1
-#         _save_image(self.filename, self.filetype, self.dpi)
-#         if self.show:
-#             plt.show()
-# 
-# 
-#     def _residual_plot(self, ax, depths, data, res_type):
-#         """
-#         Plots the residuals with magnitude
-#         """
-#         slope, intercept, _, pval, _ = linregress(depths, data[res_type])
-#         print("Depth (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
-#             intercept, slope, pval))
-#         model_x = np.arange(np.min(depths),
-#                             np.max(depths) + 1.0,
-#                             1.0)
-#         model_y = intercept + slope * model_x
-#         ax.plot(depths,
-#                 data[res_type],
-#                 'o',
-#                 markeredgecolor='Gray',
-#                 markerfacecolor='LightSteelBlue')
-#         ax.plot(model_x, model_y, 'r-', linewidth=2.0)
-#         ax.set_xlim(floor(np.min(depths)), ceil(np.max(depths)))
-#         max_lim = ceil(np.max(np.fabs(data[res_type])))
-#         ax.set_ylim(-max_lim, max_lim)
-#         ax.grid()
-#         ax.set_xlabel("Hypocentral Depth (km)", fontsize=12)
-#         ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
-#         title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
-#                        " p = %.6e " % (self.gmpe, res_type, slope, intercept,
-#                                        pval)
-#         ax.set_title(title_string, fontsize=12)
-
-#     def _get_depths(self, gmpe, imt, res_type):
-#         """
-#         Returns an array of magnitudes equal in length to the number of
-#         residuals
-#         """
-#         depths = np.array([])
-#         for i, ctxt in enumerate(self.residuals.contexts):
-#             if res_type == "Inter event":
-#                 nvals = np.ones(
-#                     len(self.residuals.unique_indices[gmpe][imt][i]))
-#             else:
-#                 nvals = np.ones(len(ctxt["Distances"].repi))
-#             # TODO This hack needs to be fixed!!!
-#             if not ctxt["Rupture"].hypo_depth:
-#                 depths = np.hstack([depths, 10.0 * nvals])
-#             else:
-#                 depths = np.hstack([depths,
-#                                     ctxt["Rupture"].hypo_depth * nvals])
-#                    depths, 
-#                    10.0 * np.ones(len(ctxt["Distances"].repi))])
-#            else:
-#                depths = np.hstack([
-#                    depths,
-#                    ctxt["Rupture"].hypo_depth *
-#                    np.ones(len(ctxt["Distances"].repi))])
-#        return depths
+        return residuals_with_depth(self.residuals, self.gmpe, self.imt)
 
 
 class ResidualWithVs30(ResidualScatterPlot):
@@ -943,83 +467,15 @@ class ResidualWithVs30(ResidualScatterPlot):
         residuals (y-axis) versus Vs30 (x-axis)
     """
     def get_plot_data(self):
-        return residuals_vs_vs30(self.residuals, self.gmpe, self.imt)
+        return residuals_with_vs30(self.residuals, self.gmpe, self.imt)
 
     def get_axis_xlim(self, res_data, res_type):
         x = res_data['x']
         return 0.1, np.max(x)
 
-#     def create_plot(self):
-#         """
-# 
-#         """
-#         data = self.residuals.residuals[self.gmpe][self.imt]
-#         if not data:
-#             print("No residuals found for %s (%s)" % (self.gmpe, self.imt))
-#             return
-# 
-#         fig = plt.figure(figsize=self.figure_size)
-#         fig.set_tight_layout(True)
-#         if self.num_plots > 1:
-#             nrow = 3
-#             ncol = 1
-#         else:
-#             nrow = 1
-#             ncol = 1
-#         tloc = 1
-#         for res_type in data.keys():
-#             vs30 = self._get_vs30(self.gmpe, self.imt, res_type)
-#             self._residual_plot(
-#                 plt.subplot(nrow, ncol, tloc),
-#                 vs30,
-#                 data,
-#                 res_type)
-#             tloc += 1
-#         _save_image(self.filename, self.filetype, self.dpi)
-#         if self.show:
-#             plt.show()
-# 
-# 
-#     def _residual_plot(self, ax, vs30, data, res_type):
-#         """
-# 
-#         """
-#         slope, intercept, _, pval, _ = linregress(vs30, data[res_type])
-#         print("Site (%s): a = %.5f  b = %.5f  p = %.5f" % (res_type,
-#             intercept, slope, pval))
-#         model_x = np.arange(np.min(vs30),
-#                             np.max(vs30) + 1.0,
-#                             1.0)
-#         model_y = intercept + slope * model_x
-#         ax.plot(vs30,
-#                 data[res_type],
-#                 'o',
-#                 markeredgecolor='Gray',
-#                 markerfacecolor='LightSteelBlue')
-#         ax.plot(model_x, model_y, 'r-', linewidth=2.0)
-#         ax.set_xlim(0.1, np.max(vs30))
-#         max_lim = ceil(np.max(np.fabs(data[res_type])))
-#         ax.set_ylim(-max_lim, max_lim)
-#         ax.grid()
-#         ax.set_xlabel("Vs30 (m/s)", fontsize=12)
-#         ax.set_ylabel("Z (%s)" % self.imt, fontsize=12)
-#         title_string = "%s - %s\n Slope = %.4e, Intercept = %7.3f"\
-#                        " p = %.6e " % (self.gmpe, res_type, slope, intercept,
-#                                        pval)
-#         ax.set_title(title_string, fontsize=12)
 
-#     def _get_vs30(self, gmpe, imt, res_type):
-#         """
-# 
-#         """
-#         vs30 = np.array([])
-#         for i, ctxt in enumerate(self.residuals.contexts):
-#             if res_type == "Inter event":
-#                 vs30 = np.hstack([vs30, ctxt["Sites"].vs30[
-#                     self.residuals.unique_indices[gmpe][imt][i]]])
-#             else:
-#                 vs30 = np.hstack([vs30, ctxt["Sites"].vs30])
-#         return vs30
+# FIXME: code below not tested and buggy (at least ResidualWithSite)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
 class ResidualWithSite(ResidualPlot):

--- a/smtk/strong_motion_selector.py
+++ b/smtk/strong_motion_selector.py
@@ -134,7 +134,7 @@ class SMRecordSelector(object):
         """
         for site_id in site_ids:
             if not site_id in self.site_ids:
-                print("Site {:w is not in database" % record_id)
+                print("Site {:w is not in database" % site_id)
         idx = []
         for iloc, record in enumerate(self.database.records):
             if record.site.id in site_ids:
@@ -199,9 +199,9 @@ class SMRecordSelector(object):
         :param float lower_depth:
             Lower event depth (km)
         """
-        if not upper_depth:
+        if upper_depth is None:
             upper_depth = 0.0
-        if not lower_depth:
+        if lower_depth is None:
             lower_depth = np.inf
         assert (lower_depth >= upper_depth)
         idx = []
@@ -219,9 +219,9 @@ class SMRecordSelector(object):
         :param float upper:
             Upper bound magnitude
         """
-        if not lower:
+        if lower is None:
             lower = -np.inf
-        if not upper:
+        if upper is None:
             upper = np.inf
         assert (upper >= lower)
         idx = []
@@ -269,7 +269,7 @@ class SMRecordSelector(object):
                 idx.append(iloc)
         return self.select_records(idx, as_db)
 
-    def select_within_vs30_range(self, lower_vs30, upper_vs30, as_db=False):
+    def select_within_vs30_range(self, lower_vs30=None, upper_vs30=None, as_db=False):
         """
         Select records within a given Vs30 range
         :param float lower_vs30:
@@ -277,9 +277,9 @@ class SMRecordSelector(object):
         :param float uper_vs30:
             Upper Vs30 (m/s)
         """
-        if not lower_vs30:
+        if lower_vs30 is None:
             lower_vs30 = -np.inf
-        if not upper_vs30:
+        if upper_vs30 is None:
             upper_vs30 = np.inf
         idx = []
         for iloc, record in enumerate(self.database.records):
@@ -350,7 +350,7 @@ class SMRecordSelector(object):
         return self.select_records(idx, as_db)
 
     # Distance based selection
-    def select_within_distance_range(self, distance_type, shortest, furthest,
+    def select_within_distance_range(self, distance_type, shortest=None, furthest=None,
             alternative=False, as_db=False):
         """
         Select records based on a distance range
@@ -366,6 +366,11 @@ class SMRecordSelector(object):
             as a tuple of (distance_type, shortest, furthest)
         """
         idx = []
+        if shortest is None:
+            shortest = 0.0
+        if furthest is None:
+            furthest = np.inf
+
         for iloc, record in enumerate(self.database.records):
             value = getattr(record.distance, distance_type)
             if value:
@@ -436,7 +441,7 @@ class SMRecordSelector(object):
                      np.array([record.event.latitude]),
                      None),
                 distance)
-            if isclose[0]:
+            if is_close[0]:
                 idx.append(iloc)
         return self.select_records(idx, as_db)
 

--- a/tests/residuals/residual_plots_test.py
+++ b/tests/residuals/residual_plots_test.py
@@ -1,0 +1,248 @@
+"""
+Core test suite for the database and residuals construction
+"""
+import os
+import sys
+import shutil
+import unittest
+from unittest.mock import patch
+import numpy as np
+
+from smtk.parsers.esm_flatfile_parser import ESMFlatfileParser
+import smtk.residuals.gmpe_residuals as res
+from smtk.database_visualiser import DISTANCES
+from smtk.residuals.residual_plots import residuals_density_distribution,\
+    residuals_lh_density_distribution, residuals_vs_depth, residuals_vs_mag,\
+    residuals_vs_vs30, residuals_vs_dist
+
+
+if sys.version_info[0] >= 3:
+    import pickle
+else:
+    import cPickle as pickle
+
+
+BASE_DATA_PATH = os.path.join(os.path.dirname(__file__), "data")
+
+
+EXPECTED_IDS = [
+"EMSC_20040918_0000026_RA_PYAS_0", "EMSC_20040918_0000026_RA_PYAT_0",
+"EMSC_20040918_0000026_RA_PYLI_0", "EMSC_20040918_0000026_RA_PYLL_0",
+"EMSC_20041205_0000033_CH_BNALP_0", "EMSC_20041205_0000033_CH_BOURR_0",
+"EMSC_20041205_0000033_CH_DIX_0", "EMSC_20041205_0000033_CH_EMV_0",
+"EMSC_20041205_0000033_CH_LIENZ_0", "EMSC_20041205_0000033_CH_LLS_0",
+"EMSC_20041205_0000033_CH_MMK_0", "EMSC_20041205_0000033_CH_SENIN_0",
+"EMSC_20041205_0000033_CH_SULZ_0", "EMSC_20041205_0000033_CH_VDL_0",
+"EMSC_20041205_0000033_CH_ZUR_0", "EMSC_20041205_0000033_RA_STBO_0",
+"EMSC_20130103_0000020_HL_SIVA_0", "EMSC_20130103_0000020_HL_ZKR_0",
+"EMSC_20130108_0000044_HL_ALNA_0", "EMSC_20130108_0000044_HL_AMGA_0",
+"EMSC_20130108_0000044_HL_DLFA_0", "EMSC_20130108_0000044_HL_EFSA_0",
+"EMSC_20130108_0000044_HL_KVLA_0", "EMSC_20130108_0000044_HL_LIA_0",
+"EMSC_20130108_0000044_HL_NOAC_0", "EMSC_20130108_0000044_HL_PLG_0",
+"EMSC_20130108_0000044_HL_PRK_0", "EMSC_20130108_0000044_HL_PSRA_0", 
+"EMSC_20130108_0000044_HL_SMTH_0", "EMSC_20130108_0000044_HL_TNSA_0",
+"EMSC_20130108_0000044_HL_YDRA_0", "EMSC_20130108_0000044_KO_ENZZ_0",
+"EMSC_20130108_0000044_KO_FOCM_0", "EMSC_20130108_0000044_KO_GMLD_0",
+"EMSC_20130108_0000044_KO_GOKC_0", "EMSC_20130108_0000044_KO_GOMA_0",
+"EMSC_20130108_0000044_KO_GPNR_0", "EMSC_20130108_0000044_KO_KIYI_0",
+"EMSC_20130108_0000044_KO_KRBN_0", "EMSC_20130108_0000044_KO_ORLT_0", 
+"EMSC_20130108_0000044_KO_SHAP_0"]
+
+
+class ResidualsTestCase(unittest.TestCase):
+    """
+    Core test case for the residuals objects
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Setup constructs the database from the ESM test data
+        """
+        ifile = os.path.join(BASE_DATA_PATH, "residual_tests_esm_data.csv")
+        cls.out_location = os.path.join(BASE_DATA_PATH, "residual_tests")
+        if os.path.exists(cls.out_location):
+            shutil.rmtree(cls.out_location)
+        parser = ESMFlatfileParser.autobuild("000", "ESM ALL",
+                                             cls.out_location, ifile)
+        del parser
+        cls.database_file = os.path.join(cls.out_location,
+                                         "metadatafile.pkl")
+        cls.database = None
+        with open(cls.database_file, "rb") as f:
+            cls.database = pickle.load(f)
+        cls.gsims = ["AkkarEtAlRjb2014",  "ChiouYoungs2014"]
+        cls.imts = ["PGA", "SA(1.0)"]
+
+    def _plot_data_check(self, plot_data, plot_data_is_json,
+                         expected_xlabel, expected_ylabel,
+                         additional_keys=None):
+        allkeys = ['x', 'y', 'xlabel', 'ylabel'] + \
+            ([] if not additional_keys else list(additional_keys))
+
+        for res_type in plot_data:
+            res_data = plot_data[res_type]
+            # assert we have the specified keys:
+            self.assertTrue(sorted(res_data.keys()) == sorted(allkeys))
+            self.assertTrue(len(res_data['x']) == len(res_data['y']))
+            self.assertTrue(res_data['xlabel'] == expected_xlabel)
+            self.assertTrue(res_data['ylabel'] == expected_ylabel)
+            array_type = list if plot_data_is_json else np.ndarray
+            self.assertTrue(isinstance(res_data['x'], array_type))
+            self.assertTrue(isinstance(res_data['y'], array_type))
+
+    def _hist_data_check(self, residuals, gsim, imt, plot_data, bin_width):
+        for res_type, res_data in plot_data.items():
+            pts = residuals.residuals[gsim][imt][res_type]
+            # FIXME: test below should be improved, it does not prevent
+            # "false negatives":
+            self.assertTrue(len(res_data['x']) != len(pts))
+
+    def _scatter_data_check(self, residuals, gsim, imt, plot_data):
+        for res_type, res_data in plot_data.items():
+            assert len(residuals.residuals[gsim][imt][res_type]) == \
+                len(res_data['x'])
+
+    def test_residual_density_distribution(self):
+        """
+        Tests basic execution of residual plot data.
+        Does not test correctness of values
+        """
+        residuals = res.Residuals(self.gsims, self.imts)
+        residuals.get_residuals(self.database, component="Geometric")
+        additional_keys = ['mean', 'stddev']
+
+        for gsim in self.gsims:
+            for imt in self.imts:
+                for as_json in (True, False):
+                    bin_w1, bin_w2 = 0.1, 0.2
+                    data1 = residuals_density_distribution(residuals, gsim,
+                                                           imt,
+                                                           bin_width=bin_w1,
+                                                           as_json=as_json)
+                    self._plot_data_check(data1, as_json, "Z (%s)" % imt,
+                                          "Frequency", additional_keys)
+                    data2 = residuals_density_distribution(residuals, gsim,
+                                                           imt,
+                                                           bin_width=bin_w2,
+                                                           as_json=as_json)
+                    self._plot_data_check(data2, as_json, "Z (%s)" % imt,
+                                          "Frequency", additional_keys)
+
+                # assert histogram data is ok:
+                self._hist_data_check(residuals, gsim, imt, data1, bin_w1)
+                self._hist_data_check(residuals, gsim, imt, data2, bin_w2)
+
+                # assert bin width did its job:
+                for res_type in data1:
+                    self.assertTrue(len(data1[res_type]['x']) >
+                                    len(data2[res_type]['x']))
+#         self._check_residual_dictionary_correctness(residuals.residuals)
+#         residuals.get_residual_statistics()
+
+    def test_likelihood_density_distribution(self):
+        """
+        Tests basic execution of Likelihood plot data.
+        Does not test correctness of values
+        """
+        residuals = res.Likelihood(self.gsims, self.imts)
+        residuals.get_residuals(self.database, component="Geometric")
+        additional_keys = ['median']
+
+        for gsim in self.gsims:
+            for imt in self.imts:
+                for as_json in (True, False):
+                    bin_w1, bin_w2 = 0.1, 0.2
+                    data1 = residuals_lh_density_distribution(residuals, gsim,
+                                                              imt,
+                                                              bin_width=bin_w1,
+                                                              as_json=as_json)
+                    self._plot_data_check(data1, as_json, "LH (%s)" % imt,
+                                          "Frequency", additional_keys)
+                    data2 = residuals_lh_density_distribution(residuals, gsim,
+                                                              imt,
+                                                              bin_width=bin_w2,
+                                                              as_json=as_json)
+                    self._plot_data_check(data2, as_json, "LH (%s)" % imt,
+                                          "Frequency", additional_keys)
+
+                # assert histogram data is ok:
+                self._hist_data_check(residuals, gsim, imt, data1, bin_w1)
+                self._hist_data_check(residuals, gsim, imt, data2, bin_w2)
+
+                # assert bin width did its job:
+                for res_type in data1:
+                    self.assertTrue(len(data1[res_type]['x']) >
+                                    len(data2[res_type]['x']))
+
+    def test_residuals_vs_mag_depth_vs30(self):
+        """
+        Tests basic execution of Resiuals vs (magnitude, depth, vs30) plot
+        data. Does not test correctness of values
+        """
+        residuals = res.Likelihood(self.gsims, self.imts)
+        residuals.get_residuals(self.database, component="Geometric")
+        additional_keys = ['slope', 'intercept', 'pvalue']
+
+        for gsim in self.gsims:
+            for imt in self.imts:
+                for as_json in (True, False):
+                    for func, expected_xlabel in \
+                        [(residuals_vs_depth, "Hypocentral Depth (km)"),
+                         (residuals_vs_mag, "Magnitude"),
+                         (residuals_vs_vs30, "Vs30 (m/s)")]:
+
+                        data1 = func(residuals, gsim, imt, as_json=as_json)
+                        self._plot_data_check(data1, as_json,
+                                              expected_xlabel,
+                                              "Z (%s)" % imt,
+                                              additional_keys)
+
+                        # assert histogram data is ok:
+                        self._scatter_data_check(residuals, gsim, imt,
+                                                 data1)
+
+    def test_residuals_vs_distance(self):
+        """
+        Tests basic execution of Resiuals vs distances plot
+        data. Does not test correctness of values
+        """
+        residuals = res.Likelihood(self.gsims, self.imts)
+        residuals.get_residuals(self.database, component="Geometric")
+        additional_keys = ['slope', 'intercept', 'pvalue']
+
+        for gsim in self.gsims:
+            for imt in self.imts:
+                for as_json in (True, False):
+                    for dist in DISTANCES.keys():
+                        if dist == 'r_x':
+                            # FIXME: Given the attribute
+                            # error, I suspect it is a missing flat file field
+                            # so we simply do this for the moment (however,
+                            # a scientific expertise should be required):
+                            with self.assertRaises(AttributeError):
+                                residuals_vs_dist(residuals, gsim, imt,
+                                                  dist, as_json=as_json)
+                            continue
+
+                        data1 = residuals_vs_dist(residuals, gsim, imt,
+                                                  dist, as_json=as_json)
+                        self._plot_data_check(data1, as_json,
+                                              "%s Distance (km)" % dist,
+                                              "Z (%s)" % imt,
+                                              additional_keys)
+
+                        # assert histogram data is ok:
+                        self._scatter_data_check(residuals, gsim, imt,
+                                                 data1)
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Deletes the database
+        """
+        shutil.rmtree(cls.out_location)
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()

--- a/tests/residuals/residual_plots_test.py
+++ b/tests/residuals/residual_plots_test.py
@@ -12,7 +12,7 @@ from smtk.parsers.esm_flatfile_parser import ESMFlatfileParser
 import smtk.residuals.gmpe_residuals as res
 from smtk.database_visualiser import DISTANCES
 from smtk.residuals.residual_plots import residuals_density_distribution,\
-    residuals_lh_density_distribution, residuals_vs_depth, residuals_vs_mag,\
+    likelihood_density_distribution, residuals_vs_depth, residuals_vs_mag,\
     residuals_vs_vs30, residuals_vs_dist
 
 
@@ -153,16 +153,16 @@ class ResidualsTestCase(unittest.TestCase):
             for imt in self.imts:
                 for as_json in (True, False):
                     bin_w1, bin_w2 = 0.1, 0.2
-                    data1 = residuals_lh_density_distribution(residuals, gsim,
-                                                              imt,
-                                                              bin_width=bin_w1,
-                                                              as_json=as_json)
+                    data1 = likelihood_density_distribution(residuals, gsim,
+                                                            imt,
+                                                            bin_width=bin_w1,
+                                                            as_json=as_json)
                     self._plot_data_check(data1, as_json, "LH (%s)" % imt,
                                           "Frequency", additional_keys)
-                    data2 = residuals_lh_density_distribution(residuals, gsim,
-                                                              imt,
-                                                              bin_width=bin_w2,
-                                                              as_json=as_json)
+                    data2 = likelihood_density_distribution(residuals, gsim,
+                                                            imt,
+                                                            bin_width=bin_w2,
+                                                            as_json=as_json)
                     self._plot_data_check(data2, as_json, "LH (%s)" % imt,
                                           "Frequency", additional_keys)
 

--- a/tests/residuals/residual_plots_test.py
+++ b/tests/residuals/residual_plots_test.py
@@ -1,19 +1,19 @@
 """
-Core test suite for the database and residuals construction
+Test suite for the `residual_plots` module responsible for calculating the
+data used for plotting (see `residual_plotter`)
 """
 import os
 import sys
 import shutil
 import unittest
-from unittest.mock import patch
 import numpy as np
 
 from smtk.parsers.esm_flatfile_parser import ESMFlatfileParser
 import smtk.residuals.gmpe_residuals as res
 from smtk.database_visualiser import DISTANCES
 from smtk.residuals.residual_plots import residuals_density_distribution,\
-    likelihood_density_distribution, residuals_vs_depth, residuals_vs_mag,\
-    residuals_vs_vs30, residuals_vs_dist
+    likelihood, residuals_with_depth, residuals_with_magnitude,\
+    residuals_with_vs30, residuals_with_distance
 
 
 if sys.version_info[0] >= 3:
@@ -153,16 +153,12 @@ class ResidualsTestCase(unittest.TestCase):
             for imt in self.imts:
                 for as_json in (True, False):
                     bin_w1, bin_w2 = 0.1, 0.2
-                    data1 = likelihood_density_distribution(residuals, gsim,
-                                                            imt,
-                                                            bin_width=bin_w1,
-                                                            as_json=as_json)
+                    data1 = likelihood(residuals, gsim, imt,
+                                       bin_width=bin_w1, as_json=as_json)
                     self._plot_data_check(data1, as_json, "LH (%s)" % imt,
                                           "Frequency", additional_keys)
-                    data2 = likelihood_density_distribution(residuals, gsim,
-                                                            imt,
-                                                            bin_width=bin_w2,
-                                                            as_json=as_json)
+                    data2 = likelihood(residuals, gsim, imt,
+                                       bin_width=bin_w2, as_json=as_json)
                     self._plot_data_check(data2, as_json, "LH (%s)" % imt,
                                           "Frequency", additional_keys)
 
@@ -188,9 +184,9 @@ class ResidualsTestCase(unittest.TestCase):
             for imt in self.imts:
                 for as_json in (True, False):
                     for func, expected_xlabel in \
-                        [(residuals_vs_depth, "Hypocentral Depth (km)"),
-                         (residuals_vs_mag, "Magnitude"),
-                         (residuals_vs_vs30, "Vs30 (m/s)")]:
+                        [(residuals_with_depth, "Hypocentral Depth (km)"),
+                         (residuals_with_magnitude, "Magnitude"),
+                         (residuals_with_vs30, "Vs30 (m/s)")]:
 
                         data1 = func(residuals, gsim, imt, as_json=as_json)
                         self._plot_data_check(data1, as_json,
@@ -221,12 +217,12 @@ class ResidualsTestCase(unittest.TestCase):
                             # so we simply do this for the moment (however,
                             # a scientific expertise should be required):
                             with self.assertRaises(AttributeError):
-                                residuals_vs_dist(residuals, gsim, imt,
-                                                  dist, as_json=as_json)
+                                residuals_with_distance(residuals, gsim, imt,
+                                                        dist, as_json=as_json)
                             continue
 
-                        data1 = residuals_vs_dist(residuals, gsim, imt,
-                                                  dist, as_json=as_json)
+                        data1 = residuals_with_distance(residuals, gsim, imt,
+                                                        dist, as_json=as_json)
                         self._plot_data_check(data1, as_json,
                                               "%s Distance (km)" % dist,
                                               "Z (%s)" % imt,

--- a/tests/residuals/residual_plotter_test.py
+++ b/tests/residuals/residual_plotter_test.py
@@ -1,0 +1,253 @@
+"""
+Core test suite for the database and residuals construction
+"""
+import os
+import sys
+import shutil
+import unittest
+from unittest.mock import patch
+import numpy as np
+
+from smtk.parsers.esm_flatfile_parser import ESMFlatfileParser
+import smtk.residuals.gmpe_residuals as res
+from smtk.residuals.residual_plots import residuals_density_distribution
+from smtk.residuals.residual_plotter import ResidualPlot, LikelihoodPlot,\
+    ResidualWithMagnitude, ResidualWithDepth, ResidualWithVs30, ResidualWithDistance
+from smtk.database_visualiser import DISTANCES
+
+
+if sys.version_info[0] >= 3:
+    import pickle
+else:
+    import cPickle as pickle
+
+
+BASE_DATA_PATH = os.path.join(os.path.dirname(__file__), "data")
+
+
+EXPECTED_IDS = [
+"EMSC_20040918_0000026_RA_PYAS_0", "EMSC_20040918_0000026_RA_PYAT_0",
+"EMSC_20040918_0000026_RA_PYLI_0", "EMSC_20040918_0000026_RA_PYLL_0",
+"EMSC_20041205_0000033_CH_BNALP_0", "EMSC_20041205_0000033_CH_BOURR_0",
+"EMSC_20041205_0000033_CH_DIX_0", "EMSC_20041205_0000033_CH_EMV_0",
+"EMSC_20041205_0000033_CH_LIENZ_0", "EMSC_20041205_0000033_CH_LLS_0",
+"EMSC_20041205_0000033_CH_MMK_0", "EMSC_20041205_0000033_CH_SENIN_0",
+"EMSC_20041205_0000033_CH_SULZ_0", "EMSC_20041205_0000033_CH_VDL_0",
+"EMSC_20041205_0000033_CH_ZUR_0", "EMSC_20041205_0000033_RA_STBO_0",
+"EMSC_20130103_0000020_HL_SIVA_0", "EMSC_20130103_0000020_HL_ZKR_0",
+"EMSC_20130108_0000044_HL_ALNA_0", "EMSC_20130108_0000044_HL_AMGA_0",
+"EMSC_20130108_0000044_HL_DLFA_0", "EMSC_20130108_0000044_HL_EFSA_0",
+"EMSC_20130108_0000044_HL_KVLA_0", "EMSC_20130108_0000044_HL_LIA_0",
+"EMSC_20130108_0000044_HL_NOAC_0", "EMSC_20130108_0000044_HL_PLG_0",
+"EMSC_20130108_0000044_HL_PRK_0", "EMSC_20130108_0000044_HL_PSRA_0", 
+"EMSC_20130108_0000044_HL_SMTH_0", "EMSC_20130108_0000044_HL_TNSA_0",
+"EMSC_20130108_0000044_HL_YDRA_0", "EMSC_20130108_0000044_KO_ENZZ_0",
+"EMSC_20130108_0000044_KO_FOCM_0", "EMSC_20130108_0000044_KO_GMLD_0",
+"EMSC_20130108_0000044_KO_GOKC_0", "EMSC_20130108_0000044_KO_GOMA_0",
+"EMSC_20130108_0000044_KO_GPNR_0", "EMSC_20130108_0000044_KO_KIYI_0",
+"EMSC_20130108_0000044_KO_KRBN_0", "EMSC_20130108_0000044_KO_ORLT_0", 
+"EMSC_20130108_0000044_KO_SHAP_0"]
+
+
+class ResidualsTestCase(unittest.TestCase):
+    """
+    Core test case for the residuals objects
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Setup constructs the database from the ESM test data
+        """
+        ifile = os.path.join(BASE_DATA_PATH, "residual_tests_esm_data.csv")
+        cls.out_location = os.path.join(BASE_DATA_PATH, "residual_tests")
+        if os.path.exists(cls.out_location):
+            shutil.rmtree(cls.out_location)
+        parser = ESMFlatfileParser.autobuild("000", "ESM ALL",
+                                             cls.out_location, ifile)
+        del parser
+        cls.database_file = os.path.join(cls.out_location,
+                                         "metadatafile.pkl")
+        cls.database = None
+        with open(cls.database_file, "rb") as f:
+            cls.database = pickle.load(f)
+        cls.gsims = ["AkkarEtAlRjb2014",  "ChiouYoungs2014"]
+        cls.imts = ["PGA", "SA(1.0)"]
+
+    def _plot_data_check(self, plot_data, plot_data_is_json,
+                         additional_keys=None):
+        allkeys = ['x', 'y', 'xlabel', 'ylabel'] + \
+            ([] if not additional_keys else list(additional_keys))
+
+        for res_type in plot_data:
+            res_data = plot_data[res_type]
+            # assert we have the specified keys:
+            assert sorted(res_data.keys()) == sorted(allkeys)
+            assert len(res_data['x']) == len(res_data['y'])
+            assert isinstance(res_data['xlabel'], str)
+            assert isinstance(res_data['ylabel'], str)
+            array_type = list if plot_data_is_json else np.ndarray
+            assert isinstance(res_data['x'], array_type)
+            assert isinstance(res_data['y'], array_type)
+
+    def _hist_data_check(self, residuals, gsim, imt, plot_data):
+        for res_type, res_data in plot_data.items():
+            assert len(residuals.residuals[gsim][imt][res_type]) > \
+                len(res_data['x'])
+
+    def _scatter_data_check(self, residuals, gsim, imt, plot_data):
+        for res_type, res_data in plot_data.items():
+            assert len(residuals.residuals[gsim][imt][res_type]) == \
+                len(res_data['x'])
+
+    @patch('smtk.residuals.residual_plotter.plt')
+    def tests_residual_plotter(self, mock_plt):
+        """
+        Tests basic execution of residual plot.
+        Simply tests pyplot show is called by mocking its `show` method
+        """
+        residuals = res.Residuals(self.gsims, self.imts)
+        residuals.get_residuals(self.database, component="Geometric")
+
+        plt_show_call_count = 0
+        for gsim in self.gsims:
+            for imt in self.imts:
+                ResidualPlot(residuals, gsim, imt, bin_width=0.1)
+                # assert we called pyplot show:
+                assert mock_plt.show.call_count == plt_show_call_count+1
+                ResidualPlot(residuals, gsim, imt, bin_width=0.1, show=False)
+                # assert we did NOT call pyplot show:
+                assert mock_plt.show.call_count == plt_show_call_count+1
+                # increment counter:
+                plt_show_call_count += 1
+
+    @patch('smtk.residuals.residual_plotter.plt')
+    def tests_likelihood_plotter(self, mock_plt):
+        """
+        Tests basic execution of Likelihood plotD.
+        Simply tests pyplot show is called by mocking its `show` method
+        """
+        residuals = res.Likelihood(self.gsims, self.imts)
+        residuals.get_residuals(self.database, component="Geometric")
+
+        plt_show_call_count = 0
+        for gsim in self.gsims:
+            for imt in self.imts:
+                LikelihoodPlot(residuals, gsim, imt, bin_width=0.1)
+                # assert we called pyplot show:
+                assert mock_plt.show.call_count == plt_show_call_count+1
+                LikelihoodPlot(residuals, gsim, imt, bin_width=0.1, show=False)
+                # assert we did NOT call pyplot show:
+                assert mock_plt.show.call_count == plt_show_call_count+1
+                # increment counter:
+                plt_show_call_count += 1
+
+    @patch('smtk.residuals.residual_plotter.plt')
+    def tests_with_mag_vs30_depth_plotter(self, mock_plt):
+        """
+        Tests basic execution of residual with (magnitude, vs30, depth) plots.
+        Simply tests pyplot show is called by mocking its `show` method
+        """
+        residuals = res.Likelihood(self.gsims, self.imts)
+        residuals.get_residuals(self.database, component="Geometric")
+
+        plt_show_call_count = 0
+        for gsim in self.gsims:
+            for imt in self.imts:
+                for plotClass in [ResidualWithMagnitude,
+                                  ResidualWithDepth,
+                                  ResidualWithVs30]:
+                    # FIXME: we should mock Axes plot and semilogx
+                    # to test the input parameter 'plot_type'
+                    plotClass(residuals, gsim, imt, show=True)
+                    # assert we called pyplot show:
+                    assert mock_plt.show.call_count == plt_show_call_count+1
+                    plotClass(residuals, gsim, imt, show=False)
+                    # assert we did NOT call pyplot show:
+                    assert mock_plt.show.call_count == plt_show_call_count+1
+                    # increment counter:
+                    plt_show_call_count += 1
+
+    @patch('smtk.residuals.residual_plotter.plt')
+    def tests_with_distance(self, mock_plt):
+        """
+        Tests basic execution of residual with distance plots.
+        Simply tests pyplot show is called by mocking its `show` method
+        """
+        residuals = res.Likelihood(self.gsims, self.imts)
+        residuals.get_residuals(self.database, component="Geometric")
+
+        plt_show_call_count = 0
+        for gsim in self.gsims:
+            for imt in self.imts:
+                for dist in DISTANCES.keys():
+
+                    if dist == 'r_x':
+                        # as for residual_plots_test, we should confirm
+                        # with scientific expertise that this is the case:
+                        with self.assertRaises(AttributeError):
+                            ResidualWithDistance(residuals, gsim, imt,
+                                         distance_type=dist, show=True)
+                        continue
+
+                    ResidualWithDistance(residuals, gsim, imt,
+                                         distance_type=dist, show=True)
+                    # assert we called pyplot show:
+                    assert mock_plt.show.call_count == plt_show_call_count+1
+                    ResidualWithDistance(residuals, gsim, imt,
+                                         distance_type=dist, show=False)
+                    # assert we did NOT call pyplot show:
+                    assert mock_plt.show.call_count == plt_show_call_count+1
+                    # increment counter:
+                    plt_show_call_count += 1
+
+
+#         self._check_residual_dictionary_correctness(residuals.residuals)
+#         residuals.get_residual_statistics()
+
+#     def tests_likelihood_execution(self):
+#         """
+#         Tests basic execution of residuals - not correctness of values
+#         """
+#         lkh = res.Likelihood(self.gsims, self.imts)
+#         lkh.get_residuals(self.database, component="Geometric")
+#         self._check_residual_dictionary_correctness(lkh.residuals)
+#         lkh.get_likelihood_values()
+# 
+#     def tests_llh_execution(self):
+#         """
+#         Tests execution of LLH - not correctness of values
+#         """
+#         llh = res.LLH(self.gsims, self.imts)
+#         llh.get_residuals(self.database, component="Geometric")
+#         self._check_residual_dictionary_correctness(llh.residuals)
+#         llh.get_loglikelihood_values(self.imts)
+# 
+#     def tests_multivariate_llh_execution(self):
+#         """
+#         Tests execution of multivariate llh - not correctness of values
+#         """
+#         multi_llh = res.MultivariateLLH(self.gsims, self.imts)
+#         multi_llh.get_residuals(self.database, component="Geometric")
+#         self._check_residual_dictionary_correctness(multi_llh.residuals)
+#         multi_llh.get_likelihood_values()
+# 
+#     def tests_edr_execution(self):
+#         """
+#         Tests execution of EDR - not correctness of values
+#         """
+#         edr = res.EDR(self.gsims, self.imts)
+#         edr.get_residuals(self.database, component="Geometric")
+#         self._check_residual_dictionary_correctness(edr.residuals)
+#         edr.get_edr_values()
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Deletes the database
+        """
+        shutil.rmtree(cls.out_location)
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()

--- a/tests/residuals/residuals_test.py
+++ b/tests/residuals/residuals_test.py
@@ -150,3 +150,7 @@ class ResidualsTestCase(unittest.TestCase):
         Deletes the database
         """
         shutil.rmtree(cls.out_location)
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()


### PR DESCRIPTION
This PR essentially does:

1. Fixes some minor bugs found in smtk/strong_motion_selector.py (just spotted via editor highlights, no tests implemented)
2. Decouples all plot data calculation from matplotlib rendering part: the old smtk.residuals.residual_plotter.py still handles the rendering (matplotlib), but a new module (smtk.residuals.residual_plots.py) implements the core functions, so that the code is cleaner and matplotlib is not imported when only plot data is required
3. Implements tests for both the two modules above (by mocking pyplot.show and other GUI-related functions)