### PR TITLE
Handles nans in residuals plots and improves sm_table selection expressions

### DIFF
--- a/smtk/residuals/gmpe_residuals.py
+++ b/smtk/residuals/gmpe_residuals.py
@@ -643,8 +643,8 @@ class Residuals(object):
             the given `gmpe`
         """
         residuals = self.residuals[gmpe][imtx]
-        return {res_type: {"Mean": np.mean(residuals[res_type]),
-                           "Std Dev": np.std(residuals[res_type])}
+        return {res_type: {"Mean": np.nanmean(residuals[res_type]),
+                           "Std Dev": np.nanstd(residuals[res_type])}
                 for res_type in self.types[gmpe][imtx]}
 
     def pretty_print(self, filename=None, sep=","):
@@ -791,7 +791,7 @@ class Residuals(object):
         for res_type in self.types[gmpe][imt]:
             zvals = np.fabs(self.residuals[gmpe][imt][res_type])
             l_h = 1.0 - erf(zvals / sqrt(2.))
-            median_lh = scoreatpercentile(l_h, 50.0)
+            median_lh = np.nanpercentile(l_h, 50.0)
             ret[res_type] = l_h, median_lh
         return ret
 

--- a/smtk/sm_table.py
+++ b/smtk/sm_table.py
@@ -502,8 +502,10 @@ def records_where(table, condition, limit=None):
         condition = ("(pga < 0.14) | (pga > 1.1) & (pgv != nan) &
                       (event_time < '2006-01-01T00:00:00'")
 
-        for record in records_where(tabke, condition):
-            # loop through matching records
+        with GroundMotionTable(<intput_file>, <dbname>).filter(condition) \
+                as gmdb:
+            for record in records_where(gmdb.table, condition):
+                # loop through matching records
     ```
     For user trying to build expressions from input variables as python
     objects, simply use the `str(object)` function which supports datetime's,
@@ -516,7 +518,8 @@ def records_where(table, condition, limit=None):
             (str(pgamin), str(pgamax), str(float('nan')), str(dtime))
     ```
 
-    :param table: The pytables Table object. See module function `get_table`
+    :param table: The pytables Table object. E.g., the `table`
+        property of a `GroundMotionTable` object
     :param condition: a string expression denoting a selection condition.
         See https://www.pytables.org/usersguide/tutorials.html#reading-and-selecting-data-in-a-table
         If None or the empty string, no filter is applied and all records are

--- a/smtk/sm_table.py
+++ b/smtk/sm_table.py
@@ -578,10 +578,14 @@ def _normalize_condition(condition):
     nan_indices = []
     str_indices = []
     dtime_indices = []
-    result = []
+    bool_indices = []
+    result = []  # list of tokens
 
     def last_tokenstr():
         return '' if not result else result[-1][1]
+
+    _logical_op_errmsg = ('Logical operators (&|~) allowed only with '
+                          'parenthezised expressions')
 
     def raise_invalid_logical_op_if(bool_value):
         if bool_value:
@@ -595,25 +599,34 @@ def _normalize_condition(condition):
         for token in generate_tokens(StringIO(condition).readline):
             tokentype, tokenstr = token[0], token[1]
 
-            raise_invalid_logical_op_if(tokenstr in ('&', '|')
-                                        and last_tokenstr() != ')')
-            raise_invalid_logical_op_if(last_tokenstr() in ('~', '|', '&')
-                                        and tokenstr not in ('~', '('))
+            # check logical operators not around brackets. I do not know how
+            # numexpr handles that but it might be misleading for the user as
+            # these operator take priority and might lead to unwxpected results
+            if (tokenstr in ('&', '|') and last_tokenstr() != ')') or \
+                    (last_tokenstr() in ('~', '|', '&')
+                     and tokenstr not in ('~', '(')):
+                raise _syntaxerr(('Logical operators (&|~) allowed only with '
+                                  'parenthezised expressions'), token)
 
             if colname is not None:
                 if colname != tokenstr or tokentype != ttypes['NAME']:
                     is_dtime_col = getattr(dbcolumns[colname],
                                            "is_datetime_str", False)
                     if not is_dtime_col:
-                        _type_check(tokentype, tokenstr, colname,
+                        _type_check(token, colname,
                                     dbcolumns[colname], ttypes['STR'],
-                                    ttypes['NUM'])
-                    if is_dtime_col and tokentype == ttypes['STR']:
+                                    ttypes['NUM'], ttypes['NAME'])
+                    elif tokentype != ttypes['STR']:
+                        raise _syntaxerr("'%s' value must be date time ISO "
+                                         "strings (quoted)" % colname, token)
+                    if is_dtime_col:
                         dtime_indices.append(len(result))
                     elif py3 and tokentype == ttypes['STR']:
                         str_indices.append(len(result))
                     elif tokenstr == 'nan' and tokentype == ttypes['NAME']:
                         nan_indices.append(len(result))
+                    elif dbcolumns[colname].__class__.__name__.startswith('Bool'):
+                        bool_indices.append(len(result))
                 colname = None
             else:
                 if tokentype == ttypes['OP'] and tokenstr in oprs \
@@ -629,46 +642,59 @@ def _normalize_condition(condition):
         # We do not want to raise this kind of stuff, as the idea here is
         # to check only for logical operatorsm, nans, and bytes conversion
         if untokenize(result).strip() != condition.strip():
-            raise ValueError(str(terr))
+            # provide a syntaxerror with the whole string to be parsed
+            # (see function _syntaxerr below)
+            raise SyntaxError(str(terr), ('', 1, len(condition), condition))
 
-    raise_invalid_logical_op_if(last_tokenstr() in ('&', '|', '~'))
+    if last_tokenstr() in ('&', '|', '~'):
+        # provide a syntaxerror with the whole string to be parsed
+        # (see function _syntaxerr below)
+        raise SyntaxError(('Logical operators (&|~) allowed only with '
+                           'parenthezised expressions'),
+                          ('', 1, len(condition), condition))
+
     # replace nans, datetimes and strings at the real end:
-    _normalize_tokens(result, dtime_indices, str_indices, nan_indices)
+    _normalize_tokens(result, dtime_indices, str_indices, nan_indices,
+                      bool_indices)
     # return the new normalized string by untokenizing back: aside changed
     # variables, spaces are preserved except trailing ones (a the end):
     return untokenize(result)
 
 
-def _type_check(tokentype, tokenstr,  # pylint: disable=too-many-arguments
-                colname, colobj,  str_code, num_code):
+def _type_check(token, colname, colobj,  str_code, num_code, name_code):
+    tokentype, tokenstr = token[0], token[1]
     colobj_name = colobj.__class__.__name__
     if colobj_name.startswith('String') and tokentype != str_code:
-        raise ValueError("'%s' value must be strings (quoted)" %
-                         colname)
+        raise _syntaxerr("'%s' value must be strings (quoted)" % colname,
+                         token)
     elif (colobj_name.startswith('UInt')
           or colobj_name.startswith('Int')) and \
             tokentype != num_code:
-        raise ValueError("'%s' values must be integers" %
-                         colname)
+        raise _syntaxerr("'%s' values must be integers" % colname, token)
     elif colobj_name.startswith('Float'):
         if tokentype != num_code and tokenstr != 'nan':
-            raise ValueError("'%s' values must be floats or nan" %
-                             colname)
-    elif colobj_name.startswith('Bool') and tokenstr not in \
-            ('True', 'False'):
-        raise ValueError("Boolean required with '%s'" %
-                         colname)
+            raise _syntaxerr("'%s' values must be floats / nan" % colname,
+                             token)
+    elif colobj_name.startswith('Bool') and (tokentype != name_code or
+                                             tokenstr.lower() not in
+                                             ('true', 'false')):
+        raise _syntaxerr("'%s' values must be boolean (True or False, "
+                         "case insensitive)" % colname, token)
 
 
-def _normalize_tokens(tokens, dtime_indices, str_indices, nan_indices):
+def _normalize_tokens(tokens, dtime_indices, str_indices, nan_indices,
+                      bool_indices):
     for i in dtime_indices:
         tokenstr = tokens[i][1]  # it is quoted, e.g. '"string"', so use shlex:
         if tokenstr[0:1] == 'b':
             tokenstr = tokenstr[1:]
-        string = shlex.split(tokenstr)[0]
-        value = GMTableParser.timestamp(string)
+        if tokenstr[0:1] in ('"', "'"):
+            string = shlex.split(tokenstr)[0]
+            value = GMTableParser.timestamp(string)
+        else:
+            value = np.nan
         if np.isnan(value):
-            raise ValueError('not a date-time: %s' % string)
+            raise _syntaxerr('not a date-time formatted string', tokens[i])
         tokens[i][1] = str(value)
 
     for i in str_indices:
@@ -677,16 +703,41 @@ def _normalize_tokens(tokens, dtime_indices, str_indices, nan_indices):
             string = shlex.split(tokenstr)[0]
             tokens[i][1] = str(string.encode('utf8'))
 
+    for i in bool_indices:
+        # just make the boolean python compatible:
+        tokens[i][1] = tokens[i][1].lower().title()
+
     if nan_indices:
         nan_operators = {'==': '!=', '!=': '=='}
         for i in nan_indices:
             varname = tokens[i-2][1]
             operator = tokens[i-1][1]
             if operator not in nan_operators:
-                raise ValueError('only != and == can be compared with nan')
+                raise _syntaxerr('only != and == can be compared with nan',
+                                 tokens[i])
             tokens[i-1][1] = nan_operators[operator]
             tokens[i][1] = varname
 
+
+def _syntaxerr(message, token):
+    '''Build a python syntax error from the given token, with the
+    given message. Token can be a list or a Token object. If list, it must
+    have 5 elements:
+    0 type (int)
+    1 string (the token string)
+    2 start (2-element tuple: (line_start, offset_start))
+    3 end (2-element tuple: (line_end, offset_end))
+    4 line: (the currently parsed line, as string. It includes 'string')
+    '''
+    if isinstance(token, list):
+        token_line_num, token_offset = token[3]
+        token_line = token[-1]
+    else:
+        token_line_num, token_offset = token.end
+        token_line = token.line
+    # the tuple passed is (filename, lineno, offset, text)
+    return SyntaxError(message, ('', token_line_num, token_offset,
+                                 token_line[:token_offset]))
 
 ##########################################
 # GroundMotionTable/ Residuals calculation

--- a/tests/residuals/residual_plots_test.py
+++ b/tests/residuals/residual_plots_test.py
@@ -13,7 +13,7 @@ import smtk.residuals.gmpe_residuals as res
 from smtk.database_visualiser import DISTANCES
 from smtk.residuals.residual_plots import residuals_density_distribution,\
     likelihood, residuals_with_depth, residuals_with_magnitude,\
-    residuals_with_vs30, residuals_with_distance
+    residuals_with_vs30, residuals_with_distance, _tojson
 
 
 if sys.version_info[0] >= 3:
@@ -232,6 +232,14 @@ class ResidualsTestCase(unittest.TestCase):
                         self._scatter_data_check(residuals, gsim, imt,
                                                  data1)
 
+
+    def test_json(self):
+        with self.assertRaises(AttributeError):
+            # only np arrays allowed:
+            self.assertEqual(_tojson([1, np.nan, 3.7]), [1, None, 3.7])
+        self.assertEqual(_tojson(np.array([1, np.nan, 3.7]))[0], [1, None, 3.7])
+        self.assertEqual(_tojson(np.nan, np.float64(3.7)), [None, 3.7])
+        
     @classmethod
     def tearDownClass(cls):
         """

--- a/tests/sm_table_test.py
+++ b/tests/sm_table_test.py
@@ -408,6 +408,15 @@ class GroundMotionTableTestCase(unittest.TestCase):
         name = os.path.splitext(os.path.basename(self.output_file))[0]
         self.assertTrue(dbnames[0] == name)
 
+        # now a delete
+        names = get_dbnames(self.output_file)
+        assert len(names) > 0
+        GroundMotionTable(self.output_file, name, 'w').delete()
+
+        names = get_dbnames(self.output_file)
+        assert len(names) == 0
+
+
     def test_template_basic_file_selection(self):
         '''parses a sample flatfile and tests some selection syntax on it'''
         # the test file has a comma delimiter. Test that we raise with

--- a/tests/sm_table_test.py
+++ b/tests/sm_table_test.py
@@ -498,20 +498,26 @@ class GroundMotionTableTestCase(unittest.TestCase):
     def test_normalize_condition(self):
         ''' test the _normalize_condition function'''
         # these are ok because logical operators relative position is not ok
-        with self.assertRaises(ValueError):
+        with self.assertRaises(SyntaxError) as _:
             _normalize_condition("& (")
-        with self.assertRaises(ValueError):
+        self.assertEqual(_.exception.text, '&')
+        with self.assertRaises(SyntaxError) as _:
             _normalize_condition("& (")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(SyntaxError) as _:
             _normalize_condition(" & ")
-        with self.assertRaises(ValueError):
+        self.assertEqual(_.exception.text, ' &')
+        with self.assertRaises(SyntaxError) as _:
             _normalize_condition("& (abc)")
-        with self.assertRaises(ValueError):
+        self.assertEqual(_.exception.text, '&')
+        with self.assertRaises(SyntaxError) as _:
             _normalize_condition(") & (abc) | cfd")
-        with self.assertRaises(ValueError):
+        self.assertEqual(_.exception.text, ') & (abc) | cfd')
+        with self.assertRaises(SyntaxError) as _:
             _normalize_condition(") & (abc) | (cdf) ~")
-        with self.assertRaises(ValueError):
+        self.assertEqual(_.exception.text, ") & (abc) | (cdf) ~")
+        with self.assertRaises(SyntaxError) as _:
             _normalize_condition(") & (abc) | (cdf) ~ ~ ~")
+        self.assertEqual(_.exception.text, ") & (abc) | (cdf) ~ ~ ~")
 
         # these are ok because operators relative position is ok.
         # Strings are not valid python expression, but
@@ -532,6 +538,9 @@ class GroundMotionTableTestCase(unittest.TestCase):
                          "(pkw != 0.5)")
         self.assertEqual(_normalize_condition(" (pkw != 0.5) ").strip(),
                          "(pkw != 0.5)")
+        self.assertEqual(_normalize_condition("vs30_measured == True"),
+                         _normalize_condition("vs30_measured == true"),
+                         _normalize_condition("vs30_measured == TRUE"))
 
         # set a series of types and the values you want to test:
         # for ints, supply also a float, as _normalize_condition
@@ -561,40 +570,59 @@ class GroundMotionTableTestCase(unittest.TestCase):
                         # now these cases should raise:
                         for col in ['pga', 'vs30_measured', 'npass']:
                             cond = '%s %s "%s"' % (col, opr, val)
-                            with self.assertRaises(ValueError):
+                            with self.assertRaises(SyntaxError):
                                 _normalize_condition(cond)
-                    elif cond == float:
-                        cond = 'pga %s %s' % (opr, val)
-                        self.assertEqual(_normalize_condition(cond), cond)
+                    elif key == float:
+                        if val == 'nan':
+                            if val not in ('==', '!='):
+                                with self.assertRaises(SyntaxError):
+                                    _normalize_condition(cond)
+                            else:
+                                cond = 'pga %s %s' % (opr, val)
+                                expected = 'pga != pga' if val == '==' else \
+                                    'pga != pga'
+                                self.assertEqual(_normalize_condition(cond),
+                                                 expected)
                         # now these cases should raise:
                         for col in ['event_country', 'event_time',
                                     'vs30_measured', 'npass']:
-                            cond = '%s %s "%s"' % (col, opr, val)
-                            with self.assertRaises(ValueError):
+                            if col == 'npass':
+                                continue  # skip tests if col is int (npass)
+                                # and provided value is float.
+                            cond = '%s %s %s' % (col, opr, val)
+                            with self.assertRaises(SyntaxError):
                                 _normalize_condition(cond)
-                    elif cond == bool:
+                    elif key == bool:
                         cond = 'vs30_measured %s %s' % (opr, val)
                         self.assertEqual(_normalize_condition(cond), cond)
+                        # test also for boolean given as lower case:
+                        cond = ('vs30_measured %s %s' % (opr, val)).lower()
+                        self.assertEqual(_normalize_condition(cond),
+                                         cond.replace('true', 'True').
+                                         replace('false', 'False'))
                         # now these cases should raise:
                         for col in ['event_country', 'event_time', 'pga',
                                     'npass']:
-                            cond = '%s %s "%s"' % (col, opr, val)
-                            with self.assertRaises(ValueError):
+                            cond = '%s %s %s' % (col, opr, val)
+                            with self.assertRaises(SyntaxError):
                                 _normalize_condition(cond)
-                    elif cond == int:
+                    elif key == int:
                         cond = 'npass %s %s' % (opr, val)
                         self.assertEqual(_normalize_condition(cond), cond)
                         # now these cases should raise:
                         for col in ['event_country', 'event_time', 'pga',
                                     'vs30_measured']:
-                            cond = '%s %s "%s"' % (col, opr, val)
-                            with self.assertRaises(ValueError):
+                            if col == 'pga':
+                                continue  # skip tests if col is int (npass)
+                                # and provided value is float.
+                            cond = '%s %s %s' % (col, opr, val)
+                            with self.assertRaises(SyntaxError):
                                 _normalize_condition(cond)
 
         # check nan conversion (not string). Note trailing spaces stripped
         cond = "(((pga == 'nan')) | ( pga != nan)  "
         #  'pga' values must be floats or nan:
-        with self.assertRaises(ValueError):
+        with self.assertRaises(SyntaxError):
             _normalize_condition(cond)
         # Parse both nans Note trailing spaces stripped
         cond = "(((pga == nan)) | ( pga != nan)  "


### PR DESCRIPTION
This PR fixes mainly two things:

1. It handles NaN in residuals plot calculation (this should affect only the case when a user chooses a sm_table instead of a sm_database), using numpy nan-safe methods (nanmean,and so on)

2. Improves the warning and errors to be given when a user uses a numexpr expression for filtering an sm_table