### PR TITLE
implements nanlinregress in residual_plots

### DIFF
--- a/smtk/residuals/residual_plots.py
+++ b/smtk/residuals/residual_plots.py
@@ -171,7 +171,7 @@ def residuals_with_magnitude(residuals, gmpe, imt, as_json=False):
     for res_type in data.keys():
 
         x = _get_magnitudes(residuals, gmpe, imt, res_type)
-        slope, intercept, _, pval, _ = linregress(x, data[res_type])
+        slope, intercept, _, pval, _ = _nanlinregress(x, data[res_type])
         y = data[res_type]
 
         if as_json:
@@ -229,7 +229,7 @@ def residuals_with_vs30(residuals, gmpe, imt, as_json=False):
     for res_type in data.keys():
 
         x = _get_vs30(residuals, gmpe, imt, res_type)
-        slope, intercept, _, pval, _ = linregress(x, data[res_type])
+        slope, intercept, _, pval, _ = _nanlinregress(x, data[res_type])
         y = data[res_type]
 
         if as_json:
@@ -281,7 +281,7 @@ def residuals_with_distance(residuals, gmpe, imt, distance_type="rjb",
     for res_type in data.keys():
 
         x = _get_distances(residuals, gmpe, imt, res_type, distance_type)
-        slope, intercept, _, pval, _ = linregress(x, data[res_type])
+        slope, intercept, _, pval, _ = _nanlinregress(x, data[res_type])
         y = data[res_type]
 
         if as_json:
@@ -338,7 +338,7 @@ def residuals_with_depth(residuals, gmpe, imt, as_json=False):
     for res_type in data.keys():
 
         x = _get_depths(residuals, gmpe, imt, res_type)
-        slope, intercept, _, pval, _ = linregress(x, data[res_type])
+        slope, intercept, _, pval, _ = _nanlinregress(x, data[res_type])
         y = data[res_type]
 
         if as_json:
@@ -372,3 +372,13 @@ def _get_depths(residuals, gmpe, imt, res_type):
             depths = np.hstack([depths,
                                 ctxt["Rupture"].hypo_depth * nvals])
     return depths
+
+
+def _nanlinregress(x, y):
+    '''Calls scipy linregress only on finite numbers of x and y'''
+    finite = np.isfinite(x) & np.isfinite(y)
+    if not finite.any():
+        # empty arrays passed to linreg raise ValueError:
+        # force returning an object with nans:
+        return linregress([np.nan], [np.nan])
+    return linregress(x[finite], y[finite])

--- a/tests/residuals/residual_plots_test.py
+++ b/tests/residuals/residual_plots_test.py
@@ -7,13 +7,14 @@ import sys
 import shutil
 import unittest
 import numpy as np
+from scipy.stats import linregress
 
 from smtk.parsers.esm_flatfile_parser import ESMFlatfileParser
 import smtk.residuals.gmpe_residuals as res
 from smtk.database_visualiser import DISTANCES
 from smtk.residuals.residual_plots import residuals_density_distribution,\
     likelihood, residuals_with_depth, residuals_with_magnitude,\
-    residuals_with_vs30, residuals_with_distance, _tojson
+    residuals_with_vs30, residuals_with_distance, _tojson, _nanlinregress
 
 
 if sys.version_info[0] >= 3:
@@ -239,7 +240,32 @@ class ResidualsTestCase(unittest.TestCase):
             self.assertEqual(_tojson([1, np.nan, 3.7]), [1, None, 3.7])
         self.assertEqual(_tojson(np.array([1, np.nan, 3.7]))[0], [1, None, 3.7])
         self.assertEqual(_tojson(np.nan, np.float64(3.7)), [None, 3.7])
-        
+
+    def test_nanlinregress(self):
+        self._assert_linreg([1, 2], [3.5, -4], [1, 2], [3.5, -4])
+        self._assert_linreg([1, np.nan], [3.5, -4], [1], [3.5])
+        self._assert_linreg([1, 2], [np.nan, -4], [2], [4])
+        self._assert_linreg([1, np.nan], [np.nan, -4], [np.nan], [np.nan])
+        # a less edgy test case:
+        self._assert_linreg([1, np.nan, 4.5, 6], [np.nan, -4, 11, 0.005],
+                            [4.5, 6], [11, 0.005])
+    
+    def _assert_linreg(self, nanx, nany, x, y):
+        '''nanx, nany: values for _nanlinreg. x, y: values for scipy linreg.
+        Asserts the results are the same'''
+        l_1 = linregress(np.asarray(x), np.asarray(y))
+        l_2 = _nanlinregress(np.asarray(nanx), np.asarray(nany))
+
+        if np.isnan(l_1.slope):
+            self.assertTrue(np.isnan(l_2.slope))
+        else:
+            self.assertEqual(l_1.slope, l_2.slope)
+
+        if np.isnan(l_1.intercept):
+            self.assertTrue(np.isnan(l_2.intercept))
+        else:
+            self.assertEqual(l_1.intercept, l_2.intercept)
+
     @classmethod
     def tearDownClass(cls):
         """


### PR DESCRIPTION
Now residual plots calculate linear regression parameters only on non-nan values of the passed x and y arrays