### PR TITLE
Fixes for the new numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ install:
   - pip install -e .
 
 script:
-  - nosetests -vsx tests/hazard/conditional_simulation_test.py
-  - nosetests -vsx tests/intensity_measures_test.py
-  - nosetests -vsx tests/trellis/trellis_test.py
-  - nosetests -vsx tests/parsers/asa_parser_test.py
-  - nosetests -vsx tests/parsers/esm_flatfile_parser_test.py
-  - nosetests -vsx tests/residuals/residuals_test.py
+  - pytest -vsx tests/hazard/conditional_simulation_test.py
+  - pytest -vsx tests/intensity_measures_test.py
+  - pytest -vsx tests/trellis/trellis_test.py
+  - pytest -vsx tests/parsers/asa_parser_test.py
+  - pytest -vsx tests/parsers/esm_flatfile_parser_test.py
+  - pytest -vsx tests/residuals/residuals_test.py

--- a/smtk/hazard/conditional_simulation.py
+++ b/smtk/hazard/conditional_simulation.py
@@ -137,7 +137,7 @@ def conditional_simulation(
     # Make sure that sites are at the surface (to check!)
     known_sites.depths = np.zeros_like(known_sites.depths)
     unknown_sites.depths = np.zeros_like(unknown_sites.depths)
-    cov_kk = correlation_model(known_sites, imt).I
+    cov_kk = np.linalg.inv(correlation_model(known_sites, imt))
     cov_uu = correlation_model(unknown_sites, imt)
     d_k_uk = np.zeros([len(known_sites), len(unknown_sites)],
                       dtype=float)
@@ -147,15 +147,15 @@ def conditional_simulation(
         d_k_uk[iloc, :] = geodetic_distance(klons[iloc], klats[iloc],
                                             ulons, ulats)
     cov_ku = correlation_model(d_k_uk, imt)
-    mu = cov_ku.T * cov_kk * np.matrix(residuals).T
-    stddev = cov_uu - (cov_ku.T * cov_kk * cov_ku)
-    unknown_residuals = np.matrix(np.random.normal(
-        0., 1., [len(unknown_sites), nsim]))
+    mu = cov_ku.T @ cov_kk @ residuals.T
+    stddev = cov_uu - (cov_ku.T @ cov_kk @ cov_ku)
+    unknown_residuals = np.random.normal(
+        0., 1., [len(unknown_sites), nsim])
     lower_matrix = np.linalg.cholesky(stddev)
     output_residuals = np.zeros_like(unknown_residuals)
     for iloc in range(0, nsim):
         output_residuals[:, iloc] = mu + \
-            lower_matrix * unknown_residuals[:, iloc]
+            lower_matrix @ unknown_residuals[:, iloc]
     return output_residuals
 
 
@@ -220,7 +220,7 @@ def get_conditional_gmfs(
                     gmfs[gmpe][imtx][:, iloc] = np.exp(
                         mean +
                         (tau * stddev_inter) +
-                        (epsilon[:, iloc].A1 * stddev_intra))
+                        (epsilon[:, iloc] * stddev_intra))
             else:
                 epsilon = conditional_simulation(
                     known_sites,
@@ -235,5 +235,5 @@ def get_conditional_gmfs(
                     ["Total"])
                 for iloc in range(0, number_simulations):
                     gmfs[gmpe][imtx][:, iloc] = np.exp(
-                        mean + epsilon[:, iloc].A1 * stddev_total.flatten())
+                        mean + epsilon[:, iloc] * stddev_total.flatten())
     return gmfs


### PR DESCRIPTION
In the next version of the engine (3.6) we are going to upgrade numpy to the latest version, 1.16.3. This required some changes, in particular in the correlation model, that required the fixing in the SMTK that you see here. We do not plan to use the newest features from numpy for the moment, so the old version will work. The new numpy is deprecating the matrix class, regular arrays should be used instead and things like `matrix.I, matrix.A1` must be removed.

NB: while at it, I am upgrading the SMTK tests to use pytest, same as for the engine.