### PR TITLE
moves load_database into sm_database

### DIFF
--- a/smtk/__init__.py
+++ b/smtk/__init__.py
@@ -16,9 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 import os
-import pickle
 import subprocess
-from smtk.sm_database import GroundMotionDatabase
 
 
 def git_suffix(fname):
@@ -46,35 +44,6 @@ def git_suffix(fname):
             pass
 
     return ''
-
-
-def load_database(directory):
-    """
-    Wrapper function to load the metadata of a strong motion database
-    according to the filetype
-    """
-    metadata_file = None
-    filetype = None
-    fileset = os.listdir(directory)
-    for ftype in ["pkl", "json"]:
-        if ("metadatafile.%s" % ftype) in fileset:
-            metadata_file = "metadatafile.%s" % ftype
-            filetype = ftype
-            break
-    if not metadata_file:
-        raise IOError(
-            "Expected metadata file of supported type not found in %s"
-            % directory)
-    metadata_path = os.path.join(directory, metadata_file)
-    if filetype == "json":
-        # json metadata filetype
-        return GroundMotionDatabase.from_json(metadata_path)
-    elif filetype == "pkl":
-        # pkl file type
-        with open(metadata_path, "rb") as f:
-            return pickle.load(f)
-    else:
-        raise ValueError("Metadata filetype %s not supported" % ftype)
 
 
 # version is used by the setup.py

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -1230,7 +1230,7 @@ class GroundMotionDatabase(object):
 
 def load_database(directory):
     """
-    Wrapper function to load the metadata of a strong motion database
+    Wrapper function to load the metadata of a :class:`GroundMotionDatabase`
     according to the filetype
     """
     metadata_file = None

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -21,6 +21,8 @@
 Basic Pseudo-database built on top of hdf5 for a set of processed strong
 motion records
 """
+import os
+import pickle
 import json
 from datetime import datetime
 from collections import OrderedDict
@@ -1224,3 +1226,32 @@ class GroundMotionDatabase(object):
         """
         return SiteCollection([rec.site.to_openquake_site(missing_vs30)
                                for rec in self.records])
+
+
+def load_database(directory):
+    """
+    Wrapper function to load the metadata of a strong motion database
+    according to the filetype
+    """
+    metadata_file = None
+    filetype = None
+    fileset = os.listdir(directory)
+    for ftype in ["pkl", "json"]:
+        if ("metadatafile.%s" % ftype) in fileset:
+            metadata_file = "metadatafile.%s" % ftype
+            filetype = ftype
+            break
+    if not metadata_file:
+        raise IOError(
+            "Expected metadata file of supported type not found in %s"
+            % directory)
+    metadata_path = os.path.join(directory, metadata_file)
+    if filetype == "json":
+        # json metadata filetype
+        return GroundMotionDatabase.from_json(metadata_path)
+    elif filetype == "pkl":
+        # pkl file type
+        with open(metadata_path, "rb") as f:
+            return pickle.load(f)
+    else:
+        raise ValueError("Metadata filetype %s not supported" % ftype)

--- a/tests/database_io_test.py
+++ b/tests/database_io_test.py
@@ -24,7 +24,7 @@ import sys
 import json
 import pprint
 import unittest
-from smtk import load_database
+from smtk.sm_database import load_database
 from smtk.parsers.esm_flatfile_parser import ESMFlatfileParser
 
 if sys.version_info[0] >= 3:


### PR DESCRIPTION
Fixes a problem whereby `numpy` had to be installed before the program could be installed. This is fine if OpenQuake is already installed, but it breaks third-party installations like [eGSIM](https://github.com/rizac/eGSIM), making their installation still feasible but cumbersome.

What happens is that `setup.py` needs `numpy` because `smtk/__init__.py` implements a `load_database` function. After inspection, that function:

1. has no essential rationale to be imported during installation (`from smtk import load_database` is handy, not essential)
2. regardless of this issue, it really looks like being in the wrong place now, in account of the fact that it refers to only one of the two "databases" implemented in `smtk`

This PR then moves `load_database` into the `sm_database` module, removes unnecessary imports in `smtk/__init__.py` (avoiding `numpy` import), and fixed tests
  
 