### PR TITLE
Improves gsim strings in trellis and fixes setup.py issue with new pip policy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         'openquake.engine >=3.6',
         'PyYAML',
-        'matplotlib >=1.5',
+         # 'matplotlib >=1.5',
         'tables >=3.4.4',
     ],
     author='GEM Foundation',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     install_requires=[
         'openquake.engine >=3.6',
         'PyYAML',
-         # 'matplotlib >=1.5',
         'tables >=3.4.4',
     ],
     author='GEM Foundation',

--- a/smtk/rcrs.py
+++ b/smtk/rcrs.py
@@ -1,8 +1,6 @@
 """
 Implementing the abstract-like interface to be inherited by any
 database/set/collection aiming to support residuals computation on its records
-
-.. moduleauthor::  R. Zaccarelli
 """
 import sys
 from collections import OrderedDict  # FIXME In Python3.7+, dict is sufficient

--- a/smtk/sm_database.py
+++ b/smtk/sm_database.py
@@ -1,8 +1,6 @@
 """
 Basic Pseudo-database built on top of hdf5 for a set of processed strong
 motion records
-
-.. moduleauthor::  R. Zaccarelli
 """
 import os
 import pickle

--- a/smtk/sm_table.py
+++ b/smtk/sm_table.py
@@ -1,8 +1,6 @@
 """
 Basic classes for the GroundMotionTable (stored as Table in HDF5 files)
 and parsers for converting from given flatfiles in CSV formats
-
-.. moduleauthor::  R. Zaccarelli
 """
 import os
 import sys

--- a/smtk/sm_table_parsers.py
+++ b/smtk/sm_table_parsers.py
@@ -1,7 +1,5 @@
 '''
 Defines the parser for released and user defined flatfiles
-
-.. moduleauthor::  R. Zaccarelli
 '''
 from collections import OrderedDict
 import re

--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -122,7 +122,7 @@ def _get_gmpe_name(gsim):
         match = re.match(r'^GMPETable\(([^)]+?)\)$', str(gsim))
         filepath = match.group(1).split("=")[1][1:-1]
         # return a consistent name (see _check_gsim_list):
-        return 'GMPETable(%s)' % os.path.splitext(filepath.split("/")[-1])[0]
+        return 'GMPETable(%s)' % filepath
     else:
         gsim_name = gsim.__class__.__name__
         additional_args = []

--- a/smtk/trellis/trellis_plots.py
+++ b/smtk/trellis/trellis_plots.py
@@ -122,7 +122,7 @@ def _get_gmpe_name(gsim):
         match = re.match(r'^GMPETable\(([^)]+?)\)$', str(gsim))
         filepath = match.group(1).split("=")[1][1:-1]
         # return a consistent name (see _check_gsim_list):
-        return 'GMPETable(%s)' % filepath
+        return 'GMPETable(gmpe_table=%s)' % filepath
     else:
         gsim_name = gsim.__class__.__name__
         additional_args = []

--- a/tests/trellis/trellis_test.py
+++ b/tests/trellis/trellis_test.py
@@ -23,9 +23,13 @@ import unittest
 import os
 import json
 import numpy as np
+
+from openquake.hazardlib.gsim.akkar_2014 import AkkarEtAlRjb2014
+from openquake.hazardlib.gsim.bindi_2014 import BindiEtAl2014Rjb
+from openquake.hazardlib.gsim.bindi_2017 import BindiEtAl2017Rjb
+
 import smtk.trellis.trellis_plots as trpl
 import smtk.trellis.configure as rcfg
-
 
 BASE_DATA_PATH = os.path.join(os.path.dirname(__file__), "data")
 
@@ -47,13 +51,16 @@ class BaseTrellisTest(unittest.TestCase):
                         1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0,
                         3.0, 4.001, 5.0, 7.5, 10.0]
 
+        # note below some GSIMS are passed as strings, some as instances (both
+        # types are valid, in the second case the str representation is
+        # inferred, see trellis_plot.py for details):
         self.gsims = ["AkkarBommer2010", "CauzziFaccioli2008",
-                      "ChiouYoungs2008", "ZhaoEtAl2006Asc", "AkkarEtAlRjb2014",
-                      "BindiEtAl2014Rjb", "CauzziEtAl2014", "DerrasEtAl2014",
+                      "ChiouYoungs2008", "ZhaoEtAl2006Asc", AkkarEtAlRjb2014(),
+                      BindiEtAl2014Rjb(), "CauzziEtAl2014", "DerrasEtAl2014",
                       "AbrahamsonEtAl2014", "BooreEtAl2014", "ChiouYoungs2014",
                       "CampbellBozorgnia2014", "KothaEtAl2016Italy",
                       "KothaEtAl2016Other", "KothaEtAl2016Turkey",
-                      "ZhaoEtAl2016Asc", "BindiEtAl2017Rjb"]
+                      "ZhaoEtAl2016Asc", BindiEtAl2017Rjb()]
 
     def compare_jsons(self, old, new):
         """

--- a/tests/trellis/trellis_test_from_properties.py
+++ b/tests/trellis/trellis_test_from_properties.py
@@ -23,6 +23,11 @@ import unittest
 import os
 import json
 import numpy as np
+
+from openquake.hazardlib.gsim.akkar_2014 import AkkarEtAlRjb2014
+from openquake.hazardlib.gsim.bindi_2014 import BindiEtAl2014Rjb
+from openquake.hazardlib.gsim.bindi_2017 import BindiEtAl2017Rjb
+
 import smtk.trellis.trellis_plots as trpl
 import smtk.trellis.configure as rcfg
 
@@ -48,13 +53,16 @@ class BaseTrellisTest(unittest.TestCase):
                         1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0,
                         3.0, 4.001, 5.0, 7.5, 10.0]
 
+        # note below some GSIMS are passed as strings, some as instances (both
+        # types are valid, in the second case the str representation is
+        # inferred, see trellis_plot.py for details):
         self.gsims = ["AkkarBommer2010", "CauzziFaccioli2008",
-                      "ChiouYoungs2008", "ZhaoEtAl2006Asc", "AkkarEtAlRjb2014",
-                      "BindiEtAl2014Rjb", "CauzziEtAl2014", "DerrasEtAl2014",
+                      "ChiouYoungs2008", "ZhaoEtAl2006Asc", AkkarEtAlRjb2014(),
+                      BindiEtAl2014Rjb(), "CauzziEtAl2014", "DerrasEtAl2014",
                       "AbrahamsonEtAl2014", "BooreEtAl2014", "ChiouYoungs2014",
                       "CampbellBozorgnia2014", "KothaEtAl2016Italy",
                       "KothaEtAl2016Other", "KothaEtAl2016Turkey",
-                      "ZhaoEtAl2016Asc", "BindiEtAl2017Rjb"]
+                      "ZhaoEtAl2016Asc", BindiEtAl2017Rjb()]
 
     def compare_jsons(self, old, new):
         """


### PR DESCRIPTION
This PR does two things:

1. Fixes installation problems by removing matplotlib from setup.py. Not only there is no point in listing a package that is already required by OpenQuake, but **from now, with the new `pip` policiy, the matplotlib version must match that of Openquake, otherwise the install would fail**.

2. Improves the Gsim names returned by Trellis plot output, which might confuse the user (if one passes `"AkkarEtAlRjb2014"` he/she gets results for `"AkkarEtAlRjb2014(adjustment factor=0.0)"`). The standard old behaviour is still maintained if one passes Gsim as class instance. However, if the Gsim is passed as string, return the input string instead (without the Gsim default parameters used, if any).
(implementation detail: the `gsims` attribute of the class `BaseTrellis` is not anymore a list of Gsims instances, but a dict of strings mapped to Gsim instances. Looking at the code, almost every time we work with a Gsim we need also its str representation, and thus this modification incidentally makes the code also more efficient)