### PR TITLE
Fixed the tests for boolean fields in the site collection

### DIFF
--- a/smtk/rcrs.py
+++ b/smtk/rcrs.py
@@ -180,13 +180,14 @@ class ResidualsCompliantRecordSet:
         :return:  a :class:`openquake.hazardlib.contexts.SitesContext`
         '''
         ctx = SitesContext()
-        for _ in self.sites_context_attrs:
-            setattr(ctx, _, [])
+        for attr in self.sites_context_attrs:
+            setattr(ctx, attr, [])
         return ctx
 
     def create_distances_context(self):
         '''Creates, initializes and returns a distances context by setting the
-        default values of the attributes defined in `self.distances_context_attrs`.
+        default values of the attributes defined in
+        `self.distances_context_attrs`.
         The returned context is intended to be used in `self.get_contexts`.
 
         :return:  a :class:`openquake.hazardlib.contexts.DistancesContext`
@@ -221,9 +222,10 @@ class ResidualsCompliantRecordSet:
             # remove attribute if its value is empty-like
             if attval is None or not len(attval):
                 delattr(context, attname)
+            elif attname in ('vs30measured', 'backarc'):
+                setattr(context, attname, np.asarray(attval, dtype=bool))
             else:
-                # FIXME: dtype=float forces Nones to be safely converted to nan
-                # but it assumes obviously all attval elements to be numeric
+                # dtype=float forces Nones to be safely converted to nan
                 setattr(context, attname, np.asarray(attval, dtype=float))
 
     def finalize_distances_context(self, context):

--- a/smtk/residuals/gmpe_residuals.py
+++ b/smtk/residuals/gmpe_residuals.py
@@ -24,13 +24,12 @@ Module to get GMPE residuals - total, inter and intra
 from __future__ import print_function
 import sys
 import re
-import h5py
 import warnings
 import numpy as np
 from datetime import datetime
 from math import sqrt, ceil
 from scipy.special import erf
-from scipy.stats import scoreatpercentile, norm
+from scipy.stats import norm
 from scipy.linalg import solve
 from copy import deepcopy
 from collections import OrderedDict
@@ -41,12 +40,10 @@ import smtk.intensity_measures as ims
 from openquake.hazardlib import imt
 from smtk.strong_motion_selector import SMRecordSelector
 from smtk.trellis.trellis_plots import _get_gmpe_name
-from smtk.sm_table import GroundMotionTable
-from smtk.sm_utils import SCALAR_XY, get_interpolated_period,\
-    convert_accel_units
+from smtk.sm_utils import convert_accel_units
 
 GSIM_LIST = get_available_gsims()
-GSIM_KEYS = set(GSIM_LIST.keys())
+GSIM_KEYS = set(GSIM_LIST)
 
 # SCALAR_IMTS = ["PGA", "PGV", "PGD", "CAV", "Ia"]
 SCALAR_IMTS = ["PGA", "PGV"]
@@ -417,7 +414,8 @@ class Residuals(object):
                                     np.arange(len(inter_ev)))
                         else:
                             self.residuals[gmpe][imtx][res_type].extend(
-                                context["Residual"][gmpe][imtx][res_type].tolist())
+                                context["Residual"][gmpe][imtx][res_type].
+                                tolist())
                         self.modelled[gmpe][imtx][res_type].extend(
                             context["Expected"][gmpe][imtx][res_type].tolist())
 
@@ -1039,8 +1037,8 @@ class SingleStationAnalysis(object):
             #    raise ValueError("%s not supported in OpenQuake" % gmpe)
             for imtx in self.imts:
                 self.types[gmpe][imtx] = []
-                for res_type in \
-                    self.gmpe_list[gmpe].DEFINED_FOR_STANDARD_DEVIATION_TYPES:
+                for res_type in (self.gmpe_list[gmpe].
+                                 DEFINED_FOR_STANDARD_DEVIATION_TYPES):
                     self.types[gmpe][imtx].append(res_type)
 
     def get_site_residuals(self, database, component="Geometric"):

--- a/tests/residuals/residual_plots_test.py
+++ b/tests/residuals/residual_plots_test.py
@@ -233,12 +233,12 @@ class ResidualsTestCase(unittest.TestCase):
                         self._scatter_data_check(residuals, gsim, imt,
                                                  data1)
 
-
     def test_json(self):
         with self.assertRaises(AttributeError):
             # only np arrays allowed:
             self.assertEqual(_tojson([1, np.nan, 3.7]), [1, None, 3.7])
-        self.assertEqual(_tojson(np.array([1, np.nan, 3.7]))[0], [1, None, 3.7])
+        self.assertEqual(_tojson(np.array([1, np.nan, 3.7]))[0],
+                         [1, None, 3.7])
         self.assertEqual(_tojson(np.nan, np.float64(3.7)), [None, 3.7])
 
     def test_nanlinregress(self):
@@ -249,7 +249,7 @@ class ResidualsTestCase(unittest.TestCase):
         # a less edgy test case:
         self._assert_linreg([1, np.nan, 4.5, 6], [np.nan, -4, 11, 0.005],
                             [4.5, 6], [11, 0.005])
-    
+
     def _assert_linreg(self, nanx, nany, x, y):
         '''nanx, nany: values for _nanlinreg. x, y: values for scipy linreg.
         Asserts the results are the same'''
@@ -273,6 +273,6 @@ class ResidualsTestCase(unittest.TestCase):
         """
         shutil.rmtree(cls.out_location)
 
+
 if __name__ == "__main__":
-    #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()


### PR DESCRIPTION
Fixes the error in https://github.com/GEMScienceTools/gmpe-smtk/runs/1899995211?check_suite_focus=true:
```python
    def get_phi(self, C, mag, sites, nl0):
        """
        Returns the within-event variability described in equation 13, line 3
        """
        phi = C["sig3"] * np.ones(sites.vs30.shape)
>       phi[sites.vs30measured] = 0.7
E       IndexError: arrays used as indices must be of integer (or boolean) type
```
Plus some PEP8 fixes.