### PR TITLE
fix installation bug: remove newlines from setup.py description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ Copyright (C) 2014-2019 GEM Foundation
 setup(
     name='smtk',
     version=__version__,
-    description=README,
+    description=README.strip().replace("\n", " "),
     url=url,
     packages=find_packages(exclude=['tests', 'tests.*']),
     # Minimal requirements, for a complete list see requirements-*.txt


### PR DESCRIPTION
A confusing ValueError raised while running `pip install' could be fixed by stripping and replacing newlines with spaces in the field `description` of `setup.py` (tested with Python 3.9.7)